### PR TITLE
DB errors reporting improved

### DIFF
--- a/reporter/bin/check_php_log.py
+++ b/reporter/bin/check_php_log.py
@@ -24,7 +24,7 @@ reports += source.query("PHP Warning", threshold=50)
 
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/DBQuery%20errors
 source = DBQueryErrorsSource()
-reports += source.query('DBQueryError', threshold=5)
+reports += source.query('DBQueryError', threshold=20)
 
 
 logging.info('Reporting {} issues...'.format(len(reports)))

--- a/reporter/reporters.py
+++ b/reporter/reporters.py
@@ -74,7 +74,7 @@ class Jira(object):
             "project": {'key': self._project},
             "summary": report.get_summary()[:250],
             "description": description,
-            "labels": [report.get_label()]
+            "labels": report.get_labels()
         }
 
         # set default fields as defined in the config.py

--- a/reporter/reports.py
+++ b/reporter/reports.py
@@ -10,7 +10,10 @@ class Report(object):
         """ Set up the report """
         self._summary = summary
         self._description = description
-        self._label = label
+
+        self._labels = list()
+        if label:
+            self.add_label(label)
 
         self._unique_id = False
         self._counter = False
@@ -39,15 +42,19 @@ class Report(object):
         """ Get report detailed description """
         return self._description
 
-    def get_label(self):
-        """ Get report label """
-        return self._label
+    def add_label(self, label):
+        """ Add given label to the report """
+        self._labels.append(label)
+
+    def get_labels(self):
+        """ Get report labels """
+        return self._labels
 
     def __repr__(self):
         """ Returns human readable representation of the object """
-        return '<Report: {summary} [{label}] ({unique_id})>\n{description}'.format(
+        return '<Report: {summary} [{labels}] ({unique_id})>\n{description}'.format(
             summary=self.get_summary(),
-            label=self.get_label(),
+            labels=']['.join(self.get_labels()),
             unique_id=self.get_unique_id(),
             description=self.get_description()
         )

--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -310,6 +310,7 @@ class DBQueryErrorsSource(PHPLogsSource):
     FULL_MESSAGE_TEMPLATE = """
 *Query*: {query}
 *Function*: {function}
+*DB server*: {server}
 *Error*: {error}
 
 *Backtrace*:
@@ -355,11 +356,17 @@ class DBQueryErrorsSource(PHPLogsSource):
 
         backtrace = entry.get('@exception', {}).get('trace', [])
 
+        # remove server IP from error message
+        error_no_ip = context.get('error').\
+            replace('({})'.format(context.get('server')), '').\
+            strip()
+
         # format the report
         full_message = self.FULL_MESSAGE_TEMPLATE.format(
             query=query,
-            error=context.get('error'),
+            error=error_no_ip,
             function=context.get('function'),
+            server=context.get('server'),
             backtrace='\n* '.join(backtrace)
         ).strip()
 
@@ -374,7 +381,7 @@ class DBQueryErrorsSource(PHPLogsSource):
 
         return Report(
             summary='[DB error {err}] {function} - {query}'.format(
-                err=context.get('error'), function=context.get('function'), query=normalized),
+                err=error_no_ip, function=context.get('function'), query=normalized),
             description=description,
             label=self.REPORT_LABEL
         )

--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -200,8 +200,8 @@ class PHPLogsSource(KibanaSource):
     REPORT_TEMPLATE = """
 {full_message}
 
-URL: {url}
-Env: {env}
+*URL*: {url}
+*Env*: {env}
 
 {{code}}
 @source_host = {source_host}
@@ -308,11 +308,11 @@ class DBQueryErrorsSource(PHPLogsSource):
     REPORT_LABEL = 'DBQueryErrors'
 
     FULL_MESSAGE_TEMPLATE = """
-Query: {query}
-Function: {function}
-Error: {error}
+*Query*: {query}
+*Function*: {function}
+*Error*: {error}
 
-Backtrace:
+*Backtrace*:
 * {backtrace}
 """
 
@@ -373,7 +373,8 @@ Backtrace:
         ).strip()
 
         return Report(
-            summary='[DB error {}] {}'.format(context.get('error'), normalized),
+            summary='[DB error {err}] {function} - {query}'.format(
+                err=context.get('error'), function=context.get('function'), query=normalized),
             description=description,
             label=self.REPORT_LABEL
         )

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -95,8 +95,8 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         assert entry.get('@message') in report.get_description()
 
         # URL should be extracted
-        assert 'URL: http://zh.asoiaf.wikia.com/wikia.php?controller=GameGuides&method=renderpage&page=%E5%A5%94%E6%B5%81%E5%9F%8E' in report.get_description()
-        assert 'Env: Production' in report.get_description()
+        assert '*URL*: http://zh.asoiaf.wikia.com/wikia.php?controller=GameGuides&method=renderpage&page=%E5%A5%94%E6%B5%81%E5%9F%8E' in report.get_description()
+        assert '*Env*: Production' in report.get_description()
 
         # a proper label should be set
         assert report.get_label() == 'PHPErrors'

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -86,7 +86,7 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         self._source._normalize(entry)
 
         report = self._source._get_report(entry)
-        print report.get_description()  # print out to stdout, pytest will show it in case of a failure
+        print report  # print out to stdout, pytest will show it in case of a failure
 
         # report should be sent with a normalized summary set
         assert report.get_summary() == 'PHP Fatal Error:  Call to a member function getText() on a non-object in /includes/wikia/services/ArticleService.class.php on line 187'
@@ -99,7 +99,7 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         assert '*Env*: Production' in report.get_description()
 
         # a proper label should be set
-        assert report.get_label() == 'PHPErrors'
+        assert report.get_labels() == ['PHPErrors']
 
     def test_get_url_from_entry(self):
         entry = {
@@ -158,10 +158,7 @@ class DBErrorsSourceTestClass(unittest.TestCase):
         self._source._normalize(self._entry)
 
         report = self._source._get_report(self._entry)
-
-        # print out to stdout, pytest will show it in case of a failure
-        print report.get_summary()
-        print report.get_description()
+        print report  # print out to stdout, pytest will show it in case of a failure
 
         assert 'DB error 1317 Query execution was interrupted' in report.get_summary()
         assert 'DPLMain:dynamicPageList' in report.get_summary()
@@ -169,4 +166,4 @@ class DBErrorsSourceTestClass(unittest.TestCase):
 
         assert '*DB server*: 10.8.38.37' in report.get_description()
 
-        assert 'DBQueryErrors' in report.get_label()
+        assert report.get_labels() == ['DBQueryErrors']


### PR DESCRIPTION
* increase the threshold to 20 errors / hour (was 5)
* report function name in issue summary
* remove DB server IP from the report summary

@jcellary 