### PR TITLE
Introduce new source for getting queries without the LIMIT statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ lint:
 
 check-php:
 	python $(project_name)/bin/check_php_log.py
+
+sandbox:
+	python $(project_name)/bin/sandbox.py 2>&1 | less

--- a/reporter/bin/check_php_log.py
+++ b/reporter/bin/check_php_log.py
@@ -6,7 +6,7 @@ and reports issues to JIRA when given thresholds are reached
 import logging
 
 from reporter.reporters import Jira
-from reporter.sources import PHPErrorsSource, DBQueryErrorsSource
+from reporter.sources import PHPErrorsSource, DBQueryErrorsSource, DBQueryNoLimitSource
 
 logging.basicConfig(
     level=logging.INFO,
@@ -29,6 +29,9 @@ reports += source.query("PHP Strict Standards", threshold=200)
 source = DBQueryErrorsSource()
 reports += source.query('DBQueryError', threshold=20)
 
+# @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/PLATFORM-836
+source = DBQueryNoLimitSource()
+reports += source.query(query='', threshold=0)
 
 logging.info('Reporting {} issues...'.format(len(reports)))
 reporter = Jira()

--- a/reporter/bin/check_php_log.py
+++ b/reporter/bin/check_php_log.py
@@ -31,7 +31,7 @@ reports += source.query('DBQueryError', threshold=20)
 
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/PLATFORM-836
 source = DBQueryNoLimitSource()
-reports += source.query(query='', threshold=0)
+reports += source.query(query='QueryNoLimit', threshold=0)
 
 logging.info('Reporting {} issues...'.format(len(reports)))
 reporter = Jira()

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.INFO)
 reports = list()
 
 source = DBQueryNoLimitSource()
-reports += source.query(query='', threshold=0)
+reports += source.query(query='QueryNoLimit', threshold=0)
 
 for report in reports:
     print report

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""
+This script is a sandbox for testing new sources
+"""
+import logging
+from reporter.sources import PHPErrorsSource, DBQueryErrorsSource, DBQueryNoLimitSource
+
+logging.basicConfig(level=logging.INFO)
+
+reports = list()
+
+source = DBQueryNoLimitSource()
+reports += source.query(query='', threshold=0)
+
+for report in reports:
+    print report

--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -32,4 +32,8 @@ def generalize_sql(sql):
     # All numbers => N
     sql = re.sub(r'-?[0-9]+', 'N', sql)
 
+    # MW comments
+    # e.g. /* CategoryDataService::getMostVisited N.N.N.N */
+    sql = re.sub(r'\s?/\*[^\*]+\*/', '', sql)
+
     return sql.strip()

--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -438,7 +438,7 @@ The database query below returned far too many rows. Please use a proper LIMIT s
 *Function*: {function}
 *Rows returned*: {num_rows}
 
-*Backtrace*:
+h5. Backtrace
 * {backtrace}
 """
 

--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -201,7 +201,7 @@ class KibanaSource(Source):
 class PHPLogsSource(KibanaSource):
     """ Shared between PHP logs providers """
     REPORT_TEMPLATE = """
-{{noformat}}{full_message}{{noformat}}
+{full_message}
 
 *URL*: {url}
 *Env*: {env}

--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -1,5 +1,8 @@
 """
 Various data providers
+
+@see https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all  JIRA text formatting
+@see http://www.solrtutorial.com/solr-query-syntax.html                         Lucene query syntax
 """
 import hashlib
 import json
@@ -198,7 +201,7 @@ class KibanaSource(Source):
 class PHPLogsSource(KibanaSource):
     """ Shared between PHP logs providers """
     REPORT_TEMPLATE = """
-{full_message}
+{{noformat}}{full_message}{{noformat}}
 
 *URL*: {url}
 *Env*: {env}
@@ -308,12 +311,12 @@ class DBQueryErrorsSource(PHPLogsSource):
     REPORT_LABEL = 'DBQueryErrors'
 
     FULL_MESSAGE_TEMPLATE = """
-*Query*: {query}
+*Query*: {{noformat}}{query}{{noformat}}
 *Function*: {function}
 *DB server*: {server}
 *Error*: {error}
 
-*Backtrace*:
+h5. Backtrace
 * {backtrace}
 """
 

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -29,6 +29,9 @@ class UtilsTestClass(unittest.TestCase):
         assert generalize_sql("UPDATE  `user` SET user_touched = '20150112143631' WHERE user_id = '25239755'") ==\
             "UPDATE `user` SET user_touched = X"
 
+        assert generalize_sql("SELECT /* CategoryDataService::getMostVisited 207.46.13.56 */  page_id,cl_to  FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id))  WHERE cl_to = 'Characters' AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title") ==\
+            "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN(N,N,N)) ORDER BY page_title"
+
         # multiline query
         sql = """
 SELECT page_title


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-836

Example:

```
<Report: [AjaxPollClass::getVotes] The database query returns 2k rows [DBQueryNoLimit] (da3846e8dcb3fffcc5a618ce6e988b65)>
The database query below returned far too many rows. Please use a proper LIMIT statement.

*Query*: {noformat}SELECT /* AjaxPollClass::getVotes x.x.x.x */  poll_answer  FROM `poll_vote`  WHERE poll_id = '8BD193E3CD923D9F5C6A560FA545F93D'{noformat}
*Function*: AjaxPollClass::getVotes
*Rows returned*: 2215

*Backtrace*:
* /usr/wikia/slot1/3496/src/includes/db/Database.php:3513
* /usr/wikia/slot1/3496/src/includes/db/Database.php:892
* /usr/wikia/slot1/3496/src/includes/db/Database.php:1390
* /usr/wikia/slot1/3496/src/extensions/wikia/AjaxPoll/AjaxPoll_body.php:168
* /usr/wikia/slot1/3496/src/extensions/wikia/AjaxPoll/AjaxPoll_body.php:391
* /usr/wikia/slot1/3496/src/extensions/wikia/AjaxPoll/AjaxPoll.php:76
* {"function":"axAjaxPollSubmit"}
* /usr/wikia/slot1/3496/src/includes/AjaxDispatcher.php:118
* /usr/wikia/slot1/3496/src/includes/Wiki.php:629
* /usr/wikia/slot1/3496/src/includes/Wiki.php:547
* /usr/wikia/slot1/3496/src/index.php:58

*URL*: http://es.toloveru.wikia.com/index.php
*Env*: Production

{code}
@source_host = ap-s34

@context = {
 "server": "xxx", 
 "cluster": "c2", 
 "db_name": "estoloveru", 
 "server_role": "master", 
 "num_rows": 2215, 
 "elapsed": 0.0016019344329834, 
 "method": "AjaxPollClass::getVotes"
}

@fields = {
 "city_id": "106483", 
 "ip": "xxx", 
 "request_id": "mw54e276e6ae8fd6.59725294", 
 "server": "es.toloveru.wikia.com", 
 "url": "/index.php", 
 "db_name": "estoloveru", 
 "http_method": "POST", 
 "referrer": "http://es.toloveru.wikia.com/wiki/To_love_ru_Wiki"
}
{code}
```

@jcellary / @wladekb 