### PR TITLE
PLATFORM-899: report not cached wikia.php responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Automated JIRA reporting of PHP fatal errors
 ```
 virtualenv env
 source env/bin/activate
-pip install -e .
+PIP_INDEX_URL=http://pypi.wikia-services.com/simple/ pip install -e .
 ```

--- a/reporter/bin/check_php_log.py
+++ b/reporter/bin/check_php_log.py
@@ -6,7 +6,8 @@ and reports issues to JIRA when given thresholds are reached
 import logging
 
 from reporter.reporters import Jira
-from reporter.sources import PHPErrorsSource, DBQueryErrorsSource, DBQueryNoLimitSource
+from reporter.sources import PHPErrorsSource, DBQueryErrorsSource,\
+    DBQueryNoLimitSource, NotCachedWikiaApiResponsesSource
 
 logging.basicConfig(
     level=logging.INFO,
@@ -32,6 +33,10 @@ reports += source.query('DBQueryError', threshold=20)
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/PLATFORM-836
 source = DBQueryNoLimitSource()
 reports += source.query()
+
+# @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/wikia.php%20caching%20disabled
+source = NotCachedWikiaApiResponsesSource()
+reports += source.query(threshold=500)  # we serve 75k not cached responses an hour
 
 logging.info('Reporting {} issues...'.format(len(reports)))
 reporter = Jira()

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -5,12 +5,12 @@ This script is a sandbox for testing new sources
 import logging
 from reporter.sources import NotCachedWikiaApiResponsesSource
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 reports = list()
 
 source = NotCachedWikiaApiResponsesSource()
-reports += source.query(threshold=1000)  # we serve 90k not cached responses
+reports += source.query(threshold=500)  # we serve 75k not cached responses an hour
 
 for report in reports:
     print report

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -3,14 +3,14 @@
 This script is a sandbox for testing new sources
 """
 import logging
-from reporter.sources import PHPErrorsSource, DBQueryErrorsSource, DBQueryNoLimitSource
+from reporter.sources import NotCachedWikiaApiResponsesSource
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 reports = list()
 
-source = DBQueryNoLimitSource()
-reports += source.query()
+source = NotCachedWikiaApiResponsesSource()
+reports += source.query(threshold=1000)  # we serve 90k not cached responses
 
 for report in reports:
     print report

--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -509,3 +509,70 @@ h5. Backtrace
             description=description,
             label=self.REPORT_LABEL
         )
+
+
+class NotCachedWikiaApiResponsesSource(KibanaSource):
+    """ Get wikia.php API responses that are not cached """
+    REPORT_LABEL = 'APIResponsesNotCached'
+
+    FULL_MESSAGE_TEMPLATE = """
+The following wikia.php API response can probably be cached on CDN layer (and invalidated when required)
+to decrease the load on the backend servers.
+
+*Nirvana controller*: {controller}
+*Method name*: {method}
+
+To debug the request run the following command:
+
+{{noformat}}
+curl -svo /dev/null "{url}"
+{{noformat}}
+"""
+
+    LIMIT = 100000  # ~1.8mm entries daily => 75k an hour
+
+    def query(self, query='', threshold=0):
+        """ Override the default query method as we do not need arguments for this source """
+        # we do not need any specific query for additional filtering
+        # threshold not needed, report all cases
+        return super(NotCachedWikiaApiResponsesSource, self).query(
+            query=self.REPORT_LABEL, threshold=threshold)
+
+    def _get_entries(self, query):
+        """ Return matching not cached responses log entries """
+        # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/wikia.php%20caching%20disabled
+        return self._kibana.query_by_string(
+            query='@message: "wikia-php.caching-disabled" AND @fields.http_method: "GET"', limit=self.LIMIT)
+
+    def _filter(self, entry):
+        """ Remove log entries that are not coming from main DC Apache servers """
+        # filter out by host
+        # "@source_host": "ap-s10",
+        host = entry.get('@source_host', '')
+        if not host.startswith('ap-') or not is_main_dc_host(host):
+            return False
+
+        return True
+
+    def _normalize(self, entry):
+        """ Normalize the entry using the controller and method names """
+        context = entry.get('@context', dict())
+        return '{}-{}-{}'.format(self.REPORT_LABEL, context.get('controller'), context.get('method'))
+
+    def _get_report(self, entry):
+        """ Format the report to be sent to JIRA """
+        context = entry.get('@context')
+
+        # format the report
+        description = self.FULL_MESSAGE_TEMPLATE.format(
+            url=self._get_url_from_entry(entry) or 'n/a',
+            controller=context.get('controller'),
+            method=context.get('method')
+        ).strip()
+
+        return Report(
+            summary='Consider caching {controller}::{method} wikia.php API responses'.format(
+                controller=context.get('controller'), method=context.get('method')),
+            description=description,
+            label=self.REPORT_LABEL
+        )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'jira==0.32',
         'pytest==2.6.4',
         'requests-oauthlib==0.4.2',
-        'wikia.common.kibana==1.1.0',
+        'wikia.common.kibana==1.1.1',
         'wikia.common.perfmonitoring==1.0.0',
     ],
     include_package_data=True,


### PR DESCRIPTION
Report not cached GET wikia.php request responses.

Example report:

```
INFO:NotCachedWikiaApiResponsesSource:> Consider caching MercuryApiController::getWikiVariables wikia.php API responses (11544 instances)

<Report: Consider caching WikiaSearchIndexerController::get wikia.php API responses [APIResponsesNotCached] (005b2d7d46a2517e20adf06b38704709)>
The following wikia.php API response can probably be cached on CDN layer (and invalidated when required)
to decrease the load on the backend servers.

*Nirvana controller*: WikiaSearchIndexerController
*Method name*: get

To debug the request run the following command:

{noformat}
curl -svo /dev/null "http://cartoonfatness.wikia.com/wikia.php?controller=WikiaSearchIndexer&format=json&method=get&service=All&ids=25262%7C25262"
{noformat}
```