### PR TITLE
Normalize out of memory PHP fatals

### DIFF
--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -280,6 +280,9 @@ class PHPErrorsSource(PHPLogsSource):
         # normalize /tmp paths
         message = re.sub(r'/tmp/\w+', '/tmp/X', message)
 
+        # normalize "17956864 bytes"
+        message = re.sub(r'\d+ bytes', 'N bytes', message)
+
         # update the entry
         entry['@message_normalized'] = message
 

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -58,6 +58,11 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
             '@source_host': 'staging-s3'
         }) == 'PHP-PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /includes/Linker.php on line 184-Preview'
 
+        # OOM, remove "n bytes"
+        assert self._source._normalize({
+            '@message': 'PHP Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 17956864 bytes) in /usr/wikia/slot1/3853/src/skins/oasis/modules/templates/Body_Index.php on line 127',
+        }) == 'PHP-PHP Fatal error: Allowed memory size of N bytes exhausted (tried to allocate N bytes) in /skins/oasis/modules/templates/Body_Index.php on line 127-Production'
+
     def test_get_report(self):
         entry = {
             "@timestamp": "2015-01-08T09:23:00.091+00:00",


### PR DESCRIPTION
Avoid reporting duplicates like https://wikia-inc.atlassian.net/browse/ER-5901 caused by different `N bytes` fragments.

Normalize `Allowed memory size of 536870912 bytes exhausted (tried to allocate 17956864 bytes)` to `Allowed memory size of N bytes exhausted (tried to allocate N bytes)`

@jcellary 