### PR TITLE
Improve SQL normalization

### DIFF
--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -20,20 +20,20 @@ def generalize_sql(sql):
     if sql is None:
         return None
 
+    # MW comments
+    # e.g. /* CategoryDataService::getMostVisited N.N.N.N */
+    sql = re.sub(r'\s?/\*[^\*]+\*/', '', sql)
+
     sql = re.sub(r"\\\\", '', sql)
     sql = re.sub(r"\\'", '', sql)
     sql = re.sub(r'\\"', '', sql)
-    sql = re.sub(r"'.*'", 'X', sql)
-    sql = re.sub(r'".*"', 'X', sql)
+    sql = re.sub(r"'[^\']+'", 'X', sql)
+    sql = re.sub(r'"[^\"]+"', 'X', sql)
 
     # All newlines, tabs, etc replaced by single space
     sql = re.sub(r'\s+', ' ', sql)
 
     # All numbers => N
     sql = re.sub(r'-?[0-9]+', 'N', sql)
-
-    # MW comments
-    # e.g. /* CategoryDataService::getMostVisited N.N.N.N */
-    sql = re.sub(r'\s?/\*[^\*]+\*/', '', sql)
 
     return sql.strip()

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -27,10 +27,13 @@ class UtilsTestClass(unittest.TestCase):
             "SELECT entity_key FROM `wall_notification_queue` WHERE (wiki_id = ) AND (event_date > X)"
 
         assert generalize_sql("UPDATE  `user` SET user_touched = '20150112143631' WHERE user_id = '25239755'") ==\
-            "UPDATE `user` SET user_touched = X"
+            "UPDATE `user` SET user_touched = X WHERE user_id = X"
 
         assert generalize_sql("SELECT /* CategoryDataService::getMostVisited 207.46.13.56 */  page_id,cl_to  FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id))  WHERE cl_to = 'Characters' AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title") ==\
             "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN(N,N,N)) ORDER BY page_title"
+
+        assert generalize_sql("SELECT /* ArticleCommentList::getCommentList Dancin'NoViolen... */  page_id,page_title  FROM `page`  WHERE (page_title LIKE 'Dreams\_Come\_True/@comment-%' ) AND page_namespace = '1'  ORDER BY page_id DESC") ==\
+            "SELECT page_id,page_title FROM `page` WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
 
         assert generalize_sql("delete /* DatabaseBase::sourceFile( /usr/wikia/slot1/3690/src/maintenance/cleanupStarter.sql ) CreateWiki scri... */ from text where old_id not in (select rev_text_id from revision)") ==\
             "delete from text where old_id not in (select rev_text_id from revision)"


### PR DESCRIPTION
Improve normalization of queries like the following one:

```sql
SELECT /* ArticleCommentList::getCommentList FooBar... */  page_id,page_title  FROM `page`  WHERE (page_title LIKE 'Foo\_Bar/@comment-%' ) AND page_namespace = '1'  ORDER BY page_id DESC
```

and avoid [duplicates](https://wikia-inc.atlassian.net/browse/ER-5970).

@jcellary 