### PR TITLE
generalize_sql: improve handling of IN (1,2,3) statements

### DIFF
--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -37,6 +37,6 @@ def generalize_sql(sql):
     sql = re.sub(r'-?[0-9]+', 'N', sql)
 
     # WHERE foo IN ('880987','882618','708228','522330')
-    sql = re.sub(r' IN\s?\(.*\)', ' IN (XYZ)', sql)
+    sql = re.sub(r' IN\s*\([^)]+\)', ' IN (XYZ)', sql)
 
     return sql.strip()

--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -36,4 +36,7 @@ def generalize_sql(sql):
     # All numbers => N
     sql = re.sub(r'-?[0-9]+', 'N', sql)
 
+    # WHERE foo IN ('880987','882618','708228','522330')
+    sql = re.sub(r' IN\s?\(.*\)', ' IN (XYZ)', sql)
+
     return sql.strip()

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -30,13 +30,16 @@ class UtilsTestClass(unittest.TestCase):
             "UPDATE `user` SET user_touched = X WHERE user_id = X"
 
         assert generalize_sql("SELECT /* CategoryDataService::getMostVisited 207.46.13.56 */  page_id,cl_to  FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id))  WHERE cl_to = 'Characters' AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title") ==\
-            "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN(N,N,N)) ORDER BY page_title"
+            "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN (XYZ) ORDER BY page_title"
 
         assert generalize_sql("SELECT /* ArticleCommentList::getCommentList Dancin'NoViolen... */  page_id,page_title  FROM `page`  WHERE (page_title LIKE 'Dreams\_Come\_True/@comment-%' ) AND page_namespace = '1'  ORDER BY page_id DESC") ==\
             "SELECT page_id,page_title FROM `page` WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
 
         assert generalize_sql("delete /* DatabaseBase::sourceFile( /usr/wikia/slot1/3690/src/maintenance/cleanupStarter.sql ) CreateWiki scri... */ from text where old_id not in (select rev_text_id from revision)") ==\
             "delete from text where old_id not in (select rev_text_id from revision)"
+
+        assert generalize_sql("SELECT /* WallNotifications::getBackupData Craftindiedo */  id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone  FROM `wall_notification`  WHERE user_id = '24944488' AND wiki_id = '1030786' AND unique_id IN ('880987','882618','708228','522330','662055','837815','792393','341504','600103','612640','667267','482428','600389','213400','620177','164442','659210','621286','609757','575865','567668','398132','549770','495396','344814','421448','400650','411028','341771','379461','332587','314176','284499','250207','231714')  AND is_hidden = '0'  ORDER BY id") ==\
+            "SELECT id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone FROM `wall_notification` WHERE user_id = X AND wiki_id = X AND unique_id IN (XYZ) AND is_hidden = X ORDER BY id"
 
         # multiline query
         sql = """

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -30,7 +30,7 @@ class UtilsTestClass(unittest.TestCase):
             "UPDATE `user` SET user_touched = X WHERE user_id = X"
 
         assert generalize_sql("SELECT /* CategoryDataService::getMostVisited 207.46.13.56 */  page_id,cl_to  FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id))  WHERE cl_to = 'Characters' AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title") ==\
-            "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN (XYZ) ORDER BY page_title"
+            "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN (XYZ)) ORDER BY page_title"
 
         assert generalize_sql("SELECT /* ArticleCommentList::getCommentList Dancin'NoViolen... */  page_id,page_title  FROM `page`  WHERE (page_title LIKE 'Dreams\_Come\_True/@comment-%' ) AND page_namespace = '1'  ORDER BY page_id DESC") ==\
             "SELECT page_id,page_title FROM `page` WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"


### PR DESCRIPTION
Normalize

```sql
SELECT foo FROM bar WHERE id IN (1,2,3)
```

to

```sql
SELECT foo FROM bar WHERE id IN (XYZ)
```

Avoid the duplicates:

* https://wikia-inc.atlassian.net/browse/ER-6041
* https://wikia-inc.atlassian.net/browse/ER-6042

@jcellary 