### PR TITLE
Do not report DB deadlocks

### DIFF
--- a/reporter/sources.py
+++ b/reporter/sources.py
@@ -355,6 +355,8 @@ h5. Backtrace
 * {backtrace}
 """
 
+    ER_LOCK_DEADLOCK = 1213
+
     def _get_entries(self, query):
         """ Return matching exception logs """
         return self._kibana.get_rows(match={"@exception.class": query}, limit=self.LIMIT)
@@ -366,6 +368,11 @@ h5. Backtrace
         # filter out by host
         # "@source_host": "ap-s10",
         if not is_main_dc_host(host):
+            return False
+
+        # skip deadlock (PLATFORM-1110)
+        context = entry.get('@context', {})
+        if context.get('errno') == self.ER_LOCK_DEADLOCK:
             return False
 
         return True

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -179,6 +179,9 @@ class DBErrorsSourceTestClass(unittest.TestCase):
         assert self._source._filter({'@source_host': 'ap-r32'}) is False  # reston DC
         assert self._source._filter({}) is False  # empty message
 
+        assert self._source._filter({'@source_host': 'ap-s32', '@context': {"errno": 1213, "err": "Deadlock found when trying to get lock; try restarting transaction (10.8.44.31)"}}) is False  # deadlock
+        assert self._source._filter({'@source_host': 'ap-s32', '@context': {"errno": 1317, "err": "Query execution was interrupted (10.8.62.57)"}}) is True
+
     def test_get_report(self):
         self._source._normalize(self._entry)
 


### PR DESCRIPTION
As a result of https://wikia-inc.atlassian.net/browse/PLATFORM-1110 we decided to ignore DB deadlocks in Jira reporter as deadlocks are really hard to debug making such reports not actionable.

@jcellary 