### PR TITLE
PLATFORM-1221: fix Kibana permalink to a dashboard

### DIFF
--- a/reporter/sources/php.py
+++ b/reporter/sources/php.py
@@ -81,7 +81,7 @@ class PHPErrorsSource(PHPLogsSource):
 
         return self.KIBANA_URL.format(
             query=urllib.quote('@source_host: {host} AND "{message}" AND "{file}"'.format(
-                host=host_regexp, message=matches.group(1), file=matches.group(2)
+                host=host_regexp, message=matches.group(1).replace(',', ''), file=matches.group(2)
             )),
             fields=','.join(['@timestamp', '@message', '@fields.url', '@source_host'])
         )

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -86,6 +86,10 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
             '@message': 'PHP Fatal error: Call to undefined method Block::getPermissionsError() in /usr/wikia/slot1/3866/src/extensions/VisualEditor/ApiVisualEditor.php on line 449'
         }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Fatal%20error%3A%20Call%20to%20undefined%20method%20Block%3A%3AgetPermissionsError%28%29%22%20AND%20%22/src/extensions/VisualEditor/ApiVisualEditor.php%20on%20line%20449%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host'
 
+        assert self._source._get_kibana_url({
+            '@message': 'PHP Catchable fatal error: Argument 1 passed to ArticleService::getContentFromParser() must be an instance of ParserOutput, boolean given, called in /usr/wikia/slot1/4610/src/includes/wikia/services/ArticleService.class.php on line 192'
+        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Catchable%20fatal%20error%3A%20Argument%201%20passed%20to%20ArticleService%3A%3AgetContentFromParser%28%29%20must%20be%20an%20instance%20of%20ParserOutput%20boolean%20given%20called%22%20AND%20%22/src/includes/wikia/services/ArticleService.class.php%20on%20line%20192%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host'
+
         assert self._source._get_kibana_url({}) is None
 
         assert self._source._get_kibana_url({


### PR DESCRIPTION
Remove commas from Kibana URL as it causes to split the query into several subqueries.

https://wikia-inc.atlassian.net/browse/PLATFORM-1221

@idradm / @jcellary 