### PR TITLE
PHPErrorsSource: try to report issues with a URL set

### DIFF
--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -83,6 +83,7 @@ class Source(object):
                     # @see PLATFORM-1162
                     if has_all_required_fields and not normalized[key]['has_all_required_fields']:
                         normalized[key]['entry'] = entry
+                        normalized[key]['has_all_required_fields'] = True
 
             else:
                 self._logger.debug('Entry not normalized: {}'.format(entry))

--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -68,13 +68,22 @@ class Source(object):
             # all entries will be grouped
             # using the key return by _normalize method
             if key is not None:
+                has_all_required_fields = self._has_all_required_fields(entry)
+
                 if key not in normalized:
                     normalized[key] = {
-                        'cnt': 0,
-                        'entry': entry
+                        'cnt': 1,
+                        'entry': entry,
+                        'has_all_required_fields': has_all_required_fields
                     }
+                else:
+                    normalized[key]['cnt'] += 1
 
-                normalized[key]['cnt'] += 1
+                    # update the normalized entry if we finally got the full context
+                    # @see PLATFORM-1162
+                    if has_all_required_fields and not normalized[key]['has_all_required_fields']:
+                        normalized[key]['entry'] = entry
+
             else:
                 self._logger.debug('Entry not normalized: {}'.format(entry))
 
@@ -106,6 +115,14 @@ class Source(object):
             reports.append(report)
 
         return reports
+
+    @staticmethod
+    def _has_all_required_fields(entry):
+        """
+        This method is called to fill the normalized entries with all required fields
+        in case the first match does not have them
+        """
+        return True
 
     def _get_entries(self, query):
         """ This method will query the source and return matching entries """

--- a/reporter/sources/php.py
+++ b/reporter/sources/php.py
@@ -141,6 +141,12 @@ class PHPErrorsSource(PHPLogsSource):
 
         return 'PHP-{}-{}'.format(message, env)
 
+    @staticmethod
+    def _has_all_required_fields(entry):
+        # @fields.url is required
+        # see PLATFORM-1162
+        return entry.get('@fields', {}).get('url') is not None
+
     def _get_report(self, entry):
         """ Format the report to be sent to JIRA """
         description = self.REPORT_TEMPLATE.format(

--- a/reporter/test/test_source.py
+++ b/reporter/test/test_source.py
@@ -30,7 +30,10 @@ class DummySource(Source):
             },
             {
                 '@message': 'Foo-Bar',
-                '@context': [456, query]
+                '@context': [456, query],
+                '@fields': {
+                    'url': 'http://example.com'
+                }
             },
             {
                 'foo': 'bar'
@@ -53,12 +56,17 @@ class DummySource(Source):
 
         return msg.replace(' ', '-')
 
+    @staticmethod
+    def _has_all_required_fields(entry):
+        # @fields.url is required
+        return entry.get('@fields', {}).get('url') is not None
+
     def _get_report(self, entry):
         """ Generate Report instance for a given entry """
         self._reports_count += 1
 
         return Report(
-            summary='[Error] {msg}'.format(msg=entry.get('@message')),
+            summary='[Error] {msg} - {url}'.format(msg=entry.get('@message'), url=entry['@fields']['url']),
             description=json.dumps(entry.get('@context'))
         )
 
@@ -96,6 +104,6 @@ class SourceTestClass(unittest.TestCase):
         print report  # print the report in case the assertion below fails
 
         assert report.get_counter() == 2
-        assert report.get_summary() == '[Error] Foo Bar'
-        assert report.get_description() == '[123, "{query}"]'.format(query=self.QUERY)
+        assert report.get_summary() == '[Error] Foo-Bar - http://example.com'
+        assert report.get_description() == '[456, "{query}"]'.format(query=self.QUERY)
         assert report.get_unique_id() == 'e5f9ec048d1dbe19c70f720e002f9cb1'


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1162

Most of PHP warnings and fatal errors reported to LogStash do not have the `@fields.url` set which makes Jira tickets reported by our tool lacking a bit of context.

This change introduces a logic (`_has_all_required_field` helper) that tries to find an entry with all required fields (`@fields.url` in this case) to make Jira reports more useful.

@jcellary 