### PR TITLE
Normalize PHP fatal errors

### DIFF
--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -111,6 +111,9 @@ class PHPErrorsSource(PHPLogsSource):
         message = re.sub(r'Compilation failed: unmatched parentheses at offset \d+',
                          'Compilation failed: unmatched parentheses at offset N', message)
 
+        # normalize fatals (PLATFORM-1463)
+        message = re.sub(r'PHP Fatal Error:\s+', 'PHP Fatal Error: ', message, flags=re.IGNORECASE)
+
         # update the entry
         entry['@message_normalized'] = message
 

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -61,7 +61,7 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         # OOM, remove "n bytes"
         assert self._source._normalize({
             '@message': 'PHP Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 17956864 bytes) in /usr/wikia/slot1/3853/src/skins/oasis/modules/templates/Body_Index.php on line 127',
-        }) == 'PHP-PHP Fatal error: Allowed memory size of N bytes exhausted (tried to allocate N bytes) in /skins/oasis/modules/templates/Body_Index.php on line 127-Production'
+        }) == 'PHP-PHP Fatal Error: Allowed memory size of N bytes exhausted (tried to allocate N bytes) in /skins/oasis/modules/templates/Body_Index.php on line 127-Production'
 
         # remove regex modifiers details
         assert self._source._normalize({
@@ -71,6 +71,19 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         assert self._source._normalize({
             '@message': 'PHP Warning: preg_match(): Compilation failed: unmatched parentheses at offset 330 in /usr/wikia/slot1/4182/src/extensions/AbuseFilter/AbuseFilter.parser.php on line 219',
         }) == 'PHP-PHP Warning: preg_match(): Compilation failed: unmatched parentheses at offset N in /extensions/AbuseFilter/AbuseFilter.parser.php on line 219-Production'
+
+        # fatals normalization (PLATFORM-1463)
+        assert self._source._normalize({
+            '@message': 'PHP Fatal Error: Maximum execution',
+        }) == 'PHP-PHP Fatal Error: Maximum execution-Production'
+
+        assert self._source._normalize({
+            '@message': 'PHP Fatal error:  Maximum execution',
+        }) == 'PHP-PHP Fatal Error: Maximum execution-Production'
+
+        assert self._source._normalize({
+            '@message': 'PHP Fatal error: Maximum execution',
+        }) == 'PHP-PHP Fatal Error: Maximum execution-Production'
 
     def test_get_kibana_url(self):
         assert self._source._get_kibana_url({
@@ -127,7 +140,7 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         print report  # print out to stdout, pytest will show it in case of a failure
 
         # report should be sent with a normalized summary set
-        assert report.get_summary() == 'PHP Fatal Error:  Call to a member function getText() on a non-object in /includes/wikia/services/ArticleService.class.php on line 187'
+        assert report.get_summary() == 'PHP Fatal Error: Call to a member function getText() on a non-object in /includes/wikia/services/ArticleService.class.php on line 187'
 
         # the full message should be kept in the description
         assert entry.get('@message') in report.get_description()


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1463

```
2015-09-11 15:43:36 [INFO] Skipped "PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /includes/cache/MessageCache.php on line 720" (1 occurrences)
2015-09-11 15:43:36 [INFO] Skipped "PHP Fatal error:  Maximum execution time of 180 seconds exceeded in /includes/parser/Preprocessor_DOM.php on line 1105" (1 occurrences)
2015-09-11 15:43:36 [INFO] Skipped "PHP Fatal Error: Allowed memory size of N bytes exhausted (tried to allocate N bytes) in Unknown on line 0" (4 occurrences)
2015-09-11 15:43:36 [INFO] Skipped "PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /includes/parser/Preprocessor_DOM.php on line 0" (1 occurrences)
```

Report all these cases as `PHP Fatal Error`.

PHP, thank you for consistent error reporting :)

@jcellary / @wladekb 