### PR TITLE
Process all error messages reported by PHP

### DIFF
--- a/reporter/bin/check.py
+++ b/reporter/bin/check.py
@@ -6,7 +6,7 @@ and reports issues to JIRA when given thresholds are reached
 import logging
 
 from reporter.reporters import Jira
-from reporter.sources import PHPErrorsSource, DBQueryErrorsSource,\
+from reporter.sources import PHPErrorsSource, PHPExceptionsSource, DBQueryErrorsSource,\
     DBQueryNoLimitSource, NotCachedWikiaApiResponsesSource, KilledDatabaseQueriesSource, \
     PHPAssertionsSource, PandoraErrorsSource
 
@@ -26,6 +26,9 @@ reports += source.query("PHP Fatal Error", threshold=5)
 reports += source.query("PHP Catchable Fatal", threshold=5)
 reports += source.query("PHP Warning", threshold=50)
 reports += source.query("PHP Strict Standards", threshold=200)
+
+# @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/Severity%20error
+reports += PHPExceptionsSource.query(threshold=50)
 
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/DBQuery%20errors
 reports += DBQueryErrorsSource().query(threshold=20)

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -4,7 +4,7 @@ This script is a sandbox for testing new sources
 """
 import logging
 from reporter.sources import KilledDatabaseQueriesSource, PHPErrorsSource, \
-    DBQueryNoLimitSource, DBQueryErrorsSource, PHPAssertionsSource, \
+    DBQueryNoLimitSource, DBQueryErrorsSource, PHPAssertionsSource, PHPExceptionsSource, \
     PandoraErrorsSource
 
 logging.basicConfig(level=logging.INFO)
@@ -26,9 +26,11 @@ reports += source.query(threshold=20)
 
 source = PHPAssertionsSource()
 reports += source.query(threshold=5)
-"""
 
 reports += PandoraErrorsSource().query(threshold=5)
+"""
+
+reports += PHPExceptionsSource().query(threshold=50)
 
 for report in reports:
     print report

--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -165,7 +165,7 @@ class Source(object):
 
 class KibanaSource(Source):
     """ elasticsearch-powered data provider """
-    LIMIT = 100000
+    LIMIT = 100000  # limit how many rows can be fetched from elasticsearch
 
     # TODO: move to a separate class
     ENV_PREVIEW = 'Preview'

--- a/reporter/sources/php/__init__.py
+++ b/reporter/sources/php/__init__.py
@@ -2,3 +2,4 @@
 from .assertions import PHPAssertionsSource
 from .db import DBQueryErrorsSource, DBQueryNoLimitSource
 from .errors import PHPErrorsSource
+from .exceptions import PHPExceptionsSource

--- a/reporter/sources/php/common.py
+++ b/reporter/sources/php/common.py
@@ -1,3 +1,5 @@
+import re
+
 from reporter.sources.common import KibanaSource
 
 
@@ -19,3 +21,15 @@ class PHPLogsSource(KibanaSource):
 @fields = {fields_formatted}
 {{code}}
     """
+
+    @staticmethod
+    def _normalize_backtrace(trace):
+        """ Remove release-specific path  """
+        if trace is None:
+            return 'n/a'
+
+        # /usr/wikia/slot1/6875/src/includes/wikia/services/UserStatsService.class.php:452
+        # /includes/wikia/services/UserStatsService.class.php:452
+        trace = [re.sub(r'/usr/wikia/slot1/\d+/src', '', entry) for entry in trace]
+
+        return '* ' + '\n* '.join(trace)

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -68,8 +68,6 @@ h5. Backtrace
         query = context.get('query')
         normalized = generalize_sql(query)
 
-        backtrace = entry.get('@exception', {}).get('trace', [])
-
         # remove server IP from error message
         error_no_ip = context.get('error').\
             replace('({})'.format(context.get('server')), '').\
@@ -81,7 +79,7 @@ h5. Backtrace
             error=error_no_ip,
             function=context.get('function'),
             server=context.get('server'),
-            backtrace='\n* '.join(backtrace)
+            backtrace=self._normalize_backtrace(entry.get('@exception', {}).get('trace'))
         ).strip()
 
         description = self.REPORT_TEMPLATE.format(
@@ -196,14 +194,13 @@ h5. Backtrace
 
         query = entry.get('@message')
         query = re.sub(r'^SQL', '', query).strip()  # remove "SQL" message prefix
-        backtrace = entry.get('@exception', {}).get('trace', [])
 
         # format the report
         full_message = self.FULL_MESSAGE_TEMPLATE.format(
             query=query,
             function=context.get('method'),
             num_rows=context.get('num_rows'),
-            backtrace='\n* '.join(backtrace)
+            backtrace=self._normalize_backtrace(entry.get('@exception', {}).get('trace'))
         ).strip()
 
         description = self.REPORT_TEMPLATE.format(

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -53,8 +53,7 @@ h5. Backtrace
 
         return '{}-{}-{}'.format(env, exception_class or 'None', message)
 
-    def _get_report(self, entry):
-        """ Format the report to be sent to JIRA """
+    def _get_description(self, entry):
         exception = entry.get('@exception', {})
         exception_class = exception.get('class')
         message = entry.get('@normalized_message')
@@ -83,12 +82,20 @@ h5. Backtrace
             )
         )
 
+        return description
+
+    def _get_report(self, entry):
+        """ Format the report to be sent to JIRA """
+        exception = entry.get('@exception', {})
+        exception_class = exception.get('class')
+        message = entry.get('@normalized_message')
+
         report = Report(
             summary='[{exception}] {message}'.format(
                 exception=exception_class or 'Error',
                 message=message
             ),
-            description=description,
+            description=self._get_description(entry),
             label=self.REPORT_LABEL
         )
 

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -1,0 +1,101 @@
+import json
+
+from reporter.helpers import is_production_host
+from reporter.reports import Report
+
+from common import PHPLogsSource
+
+
+class PHPExceptionsSource(PHPLogsSource):
+    """
+    Report errors and exceptions logged via WikiaLogger
+    """
+    REPORT_LABEL = 'PHPExceptions'
+
+    FULL_MESSAGE_TEMPLATE = """
+h1. {exception}
+
+{message}
+
+h5. Backtrace
+{backtrace}
+"""
+
+    LIMIT = 50000
+
+    def _get_entries(self, query):
+        """ Return errors and exceptions reported via WikiaLogger with error severity """
+        return self._kibana.query_by_string(
+            query='severity:"^error" AND program: "apache2" AND -@exception.class: "DBConnectionError"',
+            limit=self.LIMIT
+        )
+
+    def _filter(self, entry):
+        # filter out by host
+        # "@source_host": "ap-s10",
+        host = entry.get('@source_host', '')
+        if not is_production_host(host):
+            return False
+
+        return True
+
+    def _normalize(self, entry):
+        """ Normalize using the exception class and message """
+        exception = entry.get('@exception', {})
+        exception_class = exception.get('class')
+        env = self._get_env_from_entry(entry)
+
+        message = entry.get('@message', '')
+
+        # use a message from the exception
+        if exception_class == 'WikiaException':
+            message = exception.get('message')
+
+        entry['@normalized_message'] = message
+
+        return '{}-{}-{}'.format(env, exception_class or 'None', message)
+
+    def _get_report(self, entry):
+        """ Format the report to be sent to JIRA """
+        exception = entry.get('@exception', {})
+        exception_class = exception.get('class')
+        message = entry.get('@normalized_message')
+
+        # format the report
+        full_message = self.FULL_MESSAGE_TEMPLATE.format(
+            exception=exception_class or 'Error',
+            message=message,
+            backtrace=self._normalize_backtrace(exception.get('trace'))
+        ).strip()
+
+        description = self.REPORT_TEMPLATE.format(
+            env=self._get_env_from_entry(entry),
+            source_host=entry.get('@source_host', 'n/a'),
+            context_formatted=json.dumps(entry.get('@context', {}), indent=True),
+            fields_formatted=json.dumps(entry.get('@fields', {}), indent=True),
+            full_message=full_message,
+            url=self._get_url_from_entry(entry) or 'n/a'
+        ).strip()
+
+        # format URL to the custom Kibana dashboard
+        description += '\n\n*Still valid?* Check [Kibana dashboard|{url}]'.format(
+            url=self.format_kibana_url(
+                query='"{}"'.format(message),
+                columns=['@timestamp', '@source_host', '@message', '@exception.message', '@fields.db_name', '@fields.url']
+            )
+        )
+
+        report = Report(
+            summary='[{exception}] {message}'.format(
+                exception=exception_class or 'Error',
+                message=message
+            ),
+            description=description,
+            label=self.REPORT_LABEL
+        )
+
+        # add a custom, per exception class label
+        if exception_class is not None:
+            report.add_label('PHP{}'.format(exception_class))
+
+        return report

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -21,8 +21,6 @@ h5. Backtrace
 {backtrace}
 """
 
-    LIMIT = 50000
-
     def _get_entries(self, query):
         """ Return errors and exceptions reported via WikiaLogger with error severity """
         return self._kibana.query_by_string(

--- a/reporter/test/test_php_exceptions_source.py
+++ b/reporter/test/test_php_exceptions_source.py
@@ -1,0 +1,20 @@
+"""
+Set of unit tests for PHPExceptionsSource
+"""
+import unittest
+
+from ..sources import PHPExceptionsSource
+
+
+class PHPExceptionsSourceTestClass(unittest.TestCase):
+    """
+    Unit tests for PHPExceptionsSource class
+    """
+    def setUp(self):
+        self._source = PHPExceptionsSource()
+
+    def test_normalize(self):
+        assert self._source._normalize({'@message': 'Foo'}) == 'Production-None-Foo'
+        assert self._source._normalize({'@message': 'Foo', '@exception': {'class': 'Exception'}}) == 'Production-Exception-Foo'
+        assert self._source._normalize({'@message': 'Foo', '@exception': {'class': 'Exception', 'message': 'Bar'}}) == 'Production-Exception-Foo'
+        assert self._source._normalize({'@message': 'Foo', '@exception': {'class': 'WikiaException', 'message': 'Bar'}}) == 'Production-WikiaException-Bar'

--- a/reporter/test/test_php_source.py
+++ b/reporter/test/test_php_source.py
@@ -1,0 +1,16 @@
+"""
+Set of unit tests for PHPLogsSource
+"""
+import unittest
+
+from ..sources.php.common import PHPLogsSource
+
+
+class PHPLogsSourceTestClass(unittest.TestCase):
+    """
+    Unit tests for PHPLogsSource class
+    """
+    def test_normalize_backtrace(self):
+        assert PHPLogsSource._normalize_backtrace(None) == 'n/a'
+        assert PHPLogsSource._normalize_backtrace(['/foo', '/bar']) == '* /foo\n* /bar'
+        assert PHPLogsSource._normalize_backtrace(['/usr/wikia/slot1/6875/src/includes/Hooks.php:216"']) == '* /includes/Hooks.php:216"'


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-765

Report errors and exceptions logged via `WikiaLogger` - https://kibana.wikia-inc.com/#/dashboard/elasticsearch/Severity%20error

```
INFO:PHPExceptionsSource:Returning 14 reports (with threshold set to 50 applied)
INFO:PHPExceptionsSource:> [Exception] DB readonly mode (531 instances)
INFO:PHPExceptionsSource:> [Error] Phalanx user IP incorrect (41478 instances)
```

+ introduce `PHPLogsSource._normalize_backtrace` and use it in DB errors and exceptions reporter

@jcellary 