### PR TITLE
PLATFORM-1512 improve how we normalize SQL parse errors to catch SQL injection tries

### DIFF
--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -56,9 +56,11 @@ h5. Backtrace
             query = context.get('query')
 
             if query is not None:
-                entry_context = entry.get('@context', {})
-                entry_context.update(context)
-                return '{}-{}'.format(generalize_sql(query), entry_context.get('errno'))
+                # merge context coming from DB error reporting with
+                # the one extracted from exception message (using self._get_context_from_entry)
+                merged_context = entry.get('@context', {})
+                merged_context.update(context)
+                return '{}-{}'.format(generalize_sql(query), merged_context.get('errno'))
 
         return None
 

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -56,8 +56,9 @@ h5. Backtrace
             query = context.get('query')
 
             if query is not None:
-                entry.get('@context', {}).update(context)
-                return '{}-{}'.format(generalize_sql(query), context.get('errno'))
+                entry_context = entry.get('@context', {})
+                entry_context.update(context)
+                return '{}-{}'.format(generalize_sql(query), entry_context.get('errno'))
 
         return None
 

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -18,7 +18,7 @@ class DBQueryErrorsSource(PHPLogsSource):
 *Error*: {error}
 
 h5. Backtrace
-* {backtrace}
+{backtrace}
 """
 
     # MySQL error codes

--- a/reporter/test/test_db_source.py
+++ b/reporter/test/test_db_source.py
@@ -1,0 +1,54 @@
+"""
+Set of unit tests for DBQueryErrorsSource
+"""
+import unittest
+
+from ..sources.php.db import DBQueryErrorsSource
+
+
+class DBQueryErrorsSourceTestClass(unittest.TestCase):
+    """
+    Unit tests for PHPLogsSource DBQueryErrorsSource
+    """
+    def test_filter(self):
+        source = DBQueryErrorsSource()
+
+        # filter by source host
+        assert source._filter({'@source_host': 'ap-s20'}) is True
+        assert source._filter({'@source_host': 'dev-foo'}) is False
+
+        # filter by MySQL error codes
+        assert source._filter({'@source_host': 'ap-s20', '@context': {'errno': 1200}}) is True
+        assert source._filter({'@source_host': 'ap-s20', '@context': {'errno': 1205}}) is False
+        assert source._filter({'@source_host': 'ap-s20', '@context': {'errno': 1213}}) is False
+
+    def test_get_context_from_entry(self):
+        entry = {
+            '@exception': {
+                'message': 'A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script\n' +
+                    "Query: SELECT foo FROM bar\n" +
+                    "Function: DPLMain:dynamicPageList\n" +
+                    "Error: 1317 Query execution was interrupted (10.8.38.37)"
+            },
+            '@context': {
+                'errno': 42,
+                'err': 'Foo'
+            }
+        }
+
+        context = DBQueryErrorsSource._get_context_from_entry(entry)
+        print context
+
+        assert context.get('error') == '42 Foo'
+        assert context.get('function') == 'DPLMain:dynamicPageList'
+        assert context.get('query') == 'SELECT foo FROM bar'
+
+    def test_normalize(self):
+        source = DBQueryErrorsSource()
+        exception = {
+            'message': 'Foo\nQuery: SELECT foo FROM bar'
+        }
+
+        assert source._normalize({}) is None
+
+        assert source._normalize({'@exception': exception, '@context': {'errno': 42, 'err': 'Err'}}) == 'SELECT foo FROM bar-42'

--- a/reporter/test/test_db_source.py
+++ b/reporter/test/test_db_source.py
@@ -8,7 +8,7 @@ from ..sources.php.db import DBQueryErrorsSource
 
 class DBQueryErrorsSourceTestClass(unittest.TestCase):
     """
-    Unit tests for PHPLogsSource DBQueryErrorsSource
+    Unit tests for DBQueryErrorsSource
     """
     def test_filter(self):
         source = DBQueryErrorsSource()

--- a/reporter/test/test_db_source.py
+++ b/reporter/test/test_db_source.py
@@ -51,4 +51,4 @@ class DBQueryErrorsSourceTestClass(unittest.TestCase):
 
         assert source._normalize({}) is None
 
-        assert source._normalize({'@exception': exception, '@context': {'errno': 42, 'err': 'Err'}}) == 'SELECT foo FROM bar-42'
+        assert source._normalize({'@exception': exception, '@context': {'errno': 42}}) == 'SELECT foo FROM bar-42'


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1512

Use function name (from the exception message) instead of the SQL query when normalizing DB errors with error code set to `ER_PARSE_ERROR`.

This will give us an automated source for tracking SQL injections tries.

Additionally, add test cases for `DBQueryErrorsSource` class.

@jcellary / @Grunny 