### PR TITLE
Improve Kibana URL generation

### DIFF
--- a/reporter/bin/check.py
+++ b/reporter/bin/check.py
@@ -12,7 +12,7 @@ from reporter.sources import PHPErrorsSource, PHPExceptionsSource, DBQueryErrors
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s %(name)-25s %(levelname)-8s %(message)s',
+    format='%(asctime)s %(name)-35s %(levelname)-8s %(message)s',
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -9,32 +9,28 @@ from reporter.sources import KilledDatabaseQueriesSource, PHPErrorsSource, \
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s %(name)-25s %(levelname)-8s %(message)s',
+    format='%(asctime)s %(name)-35s %(levelname)-8s %(message)s',
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 
 reports = list()
 
-"""
-source = KilledDatabaseQueriesSource()
-reports += source.query(threshold=0)
-
 source = PHPErrorsSource()
 reports += source.query("PHP Fatal Error", threshold=5)
 
-source = DBQueryNoLimitSource()
-reports += source.query(threshold=50)
-"""
+source = KilledDatabaseQueriesSource()
+reports += source.query(threshold=0)
+
+#source = DBQueryNoLimitSource()
+#reports += source.query(threshold=50)
 
 source = DBQueryErrorsSource()
-reports += source.query(threshold=5)
+reports += source.query(threshold=2)
 
-"""
-source = PHPAssertionsSource()
-reports += source.query(threshold=5)
+#source = PHPAssertionsSource()
+#reports += source.query(threshold=5)
 
-reports += PandoraErrorsSource().query(threshold=5)
-"""
+#reports += PandoraErrorsSource().query(threshold=5)
 
 #reports += PHPExceptionsSource().query(threshold=50)
 

--- a/reporter/reports.py
+++ b/reporter/reports.py
@@ -43,6 +43,10 @@ class Report(object):
         """ Get report detailed description """
         return self._description
 
+    def append_to_description(self, desc):
+        """ Append a text to the report description """
+        self._description += desc
+
     def add_label(self, label):
         """ Add given label to the report """
         self._labels.append(label)

--- a/reporter/sources/pandora/errors.py
+++ b/reporter/sources/pandora/errors.py
@@ -82,10 +82,6 @@ class PandoraErrorsSource(PandoraLogsSource):
             url=self._get_url_from_entry(entry) or 'n/a'
         ).strip()
 
-        kibana_url = self._get_kibana_url(entry)
-        if kibana_url:
-            description += '\n\n*Still valid?* Check [Kibana dashboard|{url}]'.format(url=kibana_url)
-
         # eg. [discussion] Unable to get the user information for userId: 23912489, Returning the default.
         summary = '[{}] {}'.format(entry.get('appname'), message)
 

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -86,6 +86,17 @@ h5. Backtrace
 
         return None
 
+    def _get_kibana_url(self, entry):
+        """
+        Get the link to Kibana dashboard showing the provided error log entry
+        """
+        context = entry.get('@context')
+
+        return self.format_kibana_url(
+            query='@exception.class: "DBQueryError" AND "{}"'.format(context.get('function')),
+            columns=['@timestamp', '@source_host', '@context.errno', '@context.err', '@fields.db_name', '@fields.url']
+        )
+
     def _get_report(self, entry):
         """ Format the report to be sent to JIRA """
         context = entry.get('@context')
@@ -115,14 +126,6 @@ h5. Backtrace
             full_message=full_message,
             url=self._get_url_from_entry(entry) or 'n/a'
         ).strip()
-
-        # format URL to the custom Kibana dashboard
-        description += '\n\n*Still valid?* Check [Kibana dashboard|{url}]'.format(
-            url=self.format_kibana_url(
-                query='@exception.class: "DBQueryError" AND "{}"'.format(context.get('function')),
-                columns=['@timestamp', '@source_host', '@context.errno', '@context.err', '@fields.db_name', '@fields.url']
-            )
-        )
 
         return Report(
             summary='[DB error {err}] {function} - {query}'.format(

--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -143,10 +143,6 @@ class PHPErrorsSource(PHPLogsSource):
             url=self._get_url_from_entry(entry) or 'n/a'
         ).strip()
 
-        kibana_url = self._get_kibana_url(entry)
-        if kibana_url:
-            description += '\n\n*Still valid?* Check [Kibana dashboard|{url}]'.format(url=kibana_url)
-
         return Report(
             summary=entry.get('@message_normalized'),
             description=description,

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -25,7 +25,8 @@ h5. Backtrace
     def _get_entries(self, query):
         """ Return errors and exceptions reported via WikiaLogger with error severity """
         return self._kibana.query_by_string(
-            query='severity:"^error" AND program: "apache2" AND -@exception.class: "DBConnectionError"',
+            # DBConnectionError exceptions are handled by DBQueryErrorsSource
+            query='severity: "error" AND @exception.class: * AND -@exception.class: "DBConnectionError"',
             limit=self.LIMIT
         )
 

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -26,7 +26,8 @@ h5. Backtrace
         """ Return errors and exceptions reported via WikiaLogger with error severity """
         return self._kibana.query_by_string(
             # DBConnectionError exceptions are handled by DBQueryErrorsSource
-            query='severity: "error" AND @exception.class: * AND -@exception.class: "DBConnectionError"',
+            # and skip wfDebugLog calls from WikiFactory
+            query='severity: "error" AND @exception.class: * AND -@exception.class: "DBConnectionError" AND -@context.logGroup: "createwiki"',
             limit=self.LIMIT
         )
 
@@ -53,6 +54,9 @@ h5. Backtrace
 
         # Remove release-specific part of a file path
         message = re.sub(r'/usr/wikia/slot\d/\d+/src', '', message)
+
+        # master fallback on blobs20141/106563095
+        message = re.sub(r'blobs\d+/\d+', 'blobsX', message)
 
         # use a message from the exception
         if exception_class == 'WikiaException':

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -61,6 +61,19 @@ h5. Backtrace
 
         return '{}-{}-{}'.format(env, exception_class or 'None', message)
 
+    def _get_kibana_url(self, entry):
+        """
+        Get Kibana dashboard URL for a given entry
+
+        It will be automatically added at the end of the report description
+        """
+        message = entry.get('@normalized_message')
+
+        return self.format_kibana_url(
+            query='"{}"'.format(message),
+            columns=['@timestamp', '@source_host', '@message', '@exception.message', '@fields.db_name', '@fields.url']
+        )
+
     def _get_description(self, entry):
         exception = entry.get('@exception', {})
         exception_class = exception.get('class')
@@ -81,14 +94,6 @@ h5. Backtrace
             full_message=full_message,
             url=self._get_url_from_entry(entry) or 'n/a'
         ).strip()
-
-        # format URL to the custom Kibana dashboard
-        description += '\n\n*Still valid?* Check [Kibana dashboard|{url}]'.format(
-            url=self.format_kibana_url(
-                query='"{}"'.format(message),
-                columns=['@timestamp', '@source_host', '@message', '@exception.message', '@fields.db_name', '@fields.url']
-            )
-        )
 
         return description
 

--- a/reporter/sources/pt_kill.py
+++ b/reporter/sources/pt_kill.py
@@ -3,7 +3,6 @@ Report slow queries killed by pt-kill script
 """
 
 import json
-import urllib
 
 from common import KibanaSource
 
@@ -35,8 +34,6 @@ This query is dead. This query is no more.
 {{code}}
 {entry}
 {{code}}
-
-*Still valid?* Check [Kibana dashboard|{kibana_url}]
 """
 
     LIMIT = 1000
@@ -59,14 +56,20 @@ This query is dead. This query is no more.
         sql = generalize_sql(entry.get('query'))
         return '{}-{}'.format(self.REPORT_LABEL, sql)
 
+    def _get_kibana_url(self, entry):
+        """
+        Get the link to Kibana dashboard showing the provided error log entry
+        """
+        method = get_method_from_query(entry.get('query'))
+
+        return self.format_kibana_url(
+            query='program: "pt-kill" AND "{}"'.format(method),
+            columns=['@source_host', 'db', 'client', 'query']
+        )
+
     def _get_report(self, entry):
         """ Format the report to be sent to JIRA """
         method = get_method_from_query(entry.get('query'))
-
-        kibana_url = self.KIBANA_URL.format(
-            query=urllib.quote('program: "pt-kill"'),
-            fields=','.join(['@source_host', 'db', 'client', 'query'])
-        )
 
         # format the report
         description = self.FULL_MESSAGE_TEMPLATE.format(
@@ -77,7 +80,6 @@ This query is dead. This query is no more.
             method=method,
             query=entry.get('query'),
             entry=json.dumps(entry, indent=True),
-            kibana_url=kibana_url
         ).strip()
 
         return Report(

--- a/reporter/test/test_php_exceptions_source.py
+++ b/reporter/test/test_php_exceptions_source.py
@@ -17,6 +17,7 @@ class PHPExceptionsSourceTestClass(unittest.TestCase):
         assert self._source._normalize({'@message': 'Foo'}) == 'Production-None-Foo'
         assert self._source._normalize({'@message': 'Server #3 (10.8.38.41) is excessively lagged (126 seconds)'}) == 'Production-None-Server #X (10.8.38.41) is excessively lagged (X seconds)'
         assert self._source._normalize({'@message': 'Template file not found: /usr/wikia/slot1/6969/src/extensions/wikia/Rail/templates/RailController_LazyForAnons.php'}) == 'Production-None-Template file not found: /extensions/wikia/Rail/templates/RailController_LazyForAnons.php'
+        assert self._source._normalize({'@message': 'ExternalStoreDB::fetchBlob master fallback on blobs20141/106563095'}) == 'Production-None-ExternalStoreDB::fetchBlob master fallback on blobsX'
 
         assert self._source._normalize({'@message': 'Foo', '@exception': {'class': 'Exception'}}) == 'Production-Exception-Foo'
         assert self._source._normalize({'@message': 'Foo', '@exception': {'class': 'Exception', 'message': 'Bar'}}) == 'Production-Exception-Foo'


### PR DESCRIPTION
Code cleanup: introduce `_get_kibana_url` method for `KibanaSource` subclasses that generate a URL to a custom Kibana dashboard.

* Generate more "precise" Kibana dashboards showing only the current issue
* Improve elasticsearch query and normalization in `PHPExceptionsSource`

Example: https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=@exception.class:%20%22DBQueryError%22%20AND%20%22SDFilter:createTempTable%22&from=6h&fields=@timestamp,@source_host,@context.errno,@context.err,@fields.db_name,@fields.url

@jcellary 