### PR TITLE
PLATFORM-1535: automate security issues reporting

### DIFF
--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -5,7 +5,7 @@ This script is a sandbox for testing new sources
 import logging
 from reporter.sources import KilledDatabaseQueriesSource, PHPErrorsSource, \
     DBQueryNoLimitSource, DBQueryErrorsSource, PHPAssertionsSource, PHPExceptionsSource, \
-    PandoraErrorsSource
+    PandoraErrorsSource, PHPSecuritySource
 
 logging.basicConfig(
     level=logging.INFO,
@@ -15,17 +15,17 @@ logging.basicConfig(
 
 reports = list()
 
-source = PHPErrorsSource()
-reports += source.query("PHP Fatal Error", threshold=5)
+#source = PHPErrorsSource()
+#reports += source.query("PHP Fatal Error", threshold=5)
 
-source = KilledDatabaseQueriesSource()
-reports += source.query(threshold=0)
+#source = KilledDatabaseQueriesSource()
+#reports += source.query(threshold=0)
 
 #source = DBQueryNoLimitSource()
 #reports += source.query(threshold=50)
 
-source = DBQueryErrorsSource()
-reports += source.query(threshold=2)
+#source = DBQueryErrorsSource()
+#reports += source.query(threshold=2)
 
 #source = PHPAssertionsSource()
 #reports += source.query(threshold=5)
@@ -33,6 +33,8 @@ reports += source.query(threshold=2)
 #reports += PandoraErrorsSource().query(threshold=5)
 
 #reports += PHPExceptionsSource().query(threshold=50)
+
+reports += PHPSecuritySource().query(threshold=0)
 
 for report in reports:
     print report

--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -27,7 +27,8 @@ class Source(object):
         - each report is than formatted
         """
 
-        self._logger.info("Query: '{}'".format(query))
+        if query != '':
+            self._logger.info("Query: '{}'".format(query))
 
         # filter the entries
         entries = [entry for entry in self._get_entries(query) if self._filter(entry)]

--- a/reporter/sources/php/__init__.py
+++ b/reporter/sources/php/__init__.py
@@ -3,3 +3,4 @@ from .assertions import PHPAssertionsSource
 from .db import DBQueryErrorsSource, DBQueryNoLimitSource
 from .errors import PHPErrorsSource
 from .exceptions import PHPExceptionsSource
+from. security import PHPSecuritySource

--- a/reporter/sources/php/common.py
+++ b/reporter/sources/php/common.py
@@ -23,6 +23,16 @@ class PHPLogsSource(KibanaSource):
     """
 
     @staticmethod
+    def _normalize_trace(trace):
+        """
+        Remove release-specific part of file paths
+
+        /usr/wikia/slot1/6875/src/includes/wikia/services/UserStatsService.class.php:452
+        /includes/wikia/services/UserStatsService.class.php:452
+        """
+        return [re.sub(r'/usr/wikia/slot1/\d+/src', '', entry) for entry in trace]
+
+    @staticmethod
     def _get_backtrace_from_exception(exception):
         """ Get the PHP backtrace from the exception object and remove release-specific path  """
         if exception is None:
@@ -40,8 +50,29 @@ class PHPLogsSource(KibanaSource):
         if file_entry is not None:
             trace = [file_entry] + trace
 
-        # /usr/wikia/slot1/6875/src/includes/wikia/services/UserStatsService.class.php:452
-        # /includes/wikia/services/UserStatsService.class.php:452
-        trace = [re.sub(r'/usr/wikia/slot1/\d+/src', '', entry) for entry in trace]
+        trace = PHPLogsSource._normalize_trace(trace)
 
         return '* ' + '\n* '.join(trace)
+
+    @staticmethod
+    def _get_wikia_caller_from_exception(exception):
+        """
+        Get the a first trace's line that is Wikia code, i.e. comes from /extensions/wikia/...
+        """
+        if exception is None:
+            return None
+
+        trace = exception.get('trace')
+        if trace is None:
+            return None
+
+        trace = PHPLogsSource._normalize_trace(trace)
+
+        for entry in trace:
+            if '/extensions/wikia/Security' in entry:
+                continue
+
+            if re.search(r'/includes/wikia/api/|/skins/oasis/modules/|/extensions/wikia/|/extensions/VisualEditor/wikia/', entry):
+                return entry
+
+        return None

--- a/reporter/sources/php/common.py
+++ b/reporter/sources/php/common.py
@@ -33,7 +33,7 @@ class PHPLogsSource(KibanaSource):
         return [re.sub(r'/usr/wikia/slot1/\d+/src', '', entry) for entry in trace]
 
     @staticmethod
-    def _get_backtrace_from_exception(exception):
+    def _get_backtrace_from_exception(exception, offset=0):
         """ Get the PHP backtrace from the exception object and remove release-specific path  """
         if exception is None:
             return 'n/a'
@@ -51,6 +51,7 @@ class PHPLogsSource(KibanaSource):
             trace = [file_entry] + trace
 
         trace = PHPLogsSource._normalize_trace(trace)
+        trace = trace[offset:]
 
         return '* ' + '\n* '.join(trace)
 

--- a/reporter/sources/php/security.py
+++ b/reporter/sources/php/security.py
@@ -24,7 +24,7 @@ h5. Backtrace
 {backtrace}
 """
 
-    LIMIT = 500
+    LIMIT = 1500
 
     def _get_entries(self, query):
         """ Return failed security assertions logs """
@@ -107,7 +107,7 @@ Please refer to [documentation on Wikia One|https://one.wikia-inc.com/wiki/User_
         full_message = self.FULL_MESSAGE_TEMPLATE.format(
             message=message,
             details=details.strip(),
-            backtrace=self._get_backtrace_from_exception(exception)
+            backtrace=self._get_backtrace_from_exception(exception, offset=5)  # skip backtrace to CSRFDetector
         ).strip()
 
         description = self.REPORT_TEMPLATE.format(

--- a/reporter/sources/php/security.py
+++ b/reporter/sources/php/security.py
@@ -24,7 +24,7 @@ h5. Backtrace
 {backtrace}
 """
 
-    LIMIT = 1500
+    LIMIT = 5000
 
     def _get_entries(self, query):
         """ Return failed security assertions logs """
@@ -98,7 +98,8 @@ Please refer to [documentation on Wikia One|https://one.wikia-inc.com/wiki/User_
 *Token checked*: {token_checked}
 *HTTP method checked*: {method_checked}
 """.format(
-                action_performed=context.get('caller'),
+                # Wikia\Security\CSRFDetector::onRevisionInsertComplete -> onRevisionInsertComplete
+                action_performed=context.get('hookName') if 'hookName' in context else context.get('caller', '').split('::').pop(),
                 token_checked='checked' if context.get('editTokenChecked') is True else '*not checked*',
                 method_checked='checked' if context.get('httpMethodChecked') is True else '*not checked*',
             )

--- a/reporter/sources/php/security.py
+++ b/reporter/sources/php/security.py
@@ -24,7 +24,7 @@ h5. Backtrace
 {backtrace}
 """
 
-    LIMIT = 5000
+    LIMIT = 25000
 
     def _get_entries(self, query):
         """ Return failed security assertions logs """

--- a/reporter/sources/php/security.py
+++ b/reporter/sources/php/security.py
@@ -1,0 +1,131 @@
+import json
+
+from reporter.helpers import is_production_host
+from reporter.reports import Report
+
+from common import PHPLogsSource
+
+
+class PHPSecuritySource(PHPLogsSource):
+    """
+    Report failed asserts reported by Wikia\Security\Exception
+
+    @see https://github.com/Wikia/app/tree/dev/extensions/wikia/Security
+    @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/PLATFORM-1540
+    """
+    REPORT_LABEL = 'CSRFDetector'
+
+    FULL_MESSAGE_TEMPLATE = """
+h2. {message}
+
+{details}
+
+h5. Backtrace
+{backtrace}
+"""
+
+    LIMIT = 500
+
+    def _get_entries(self, query):
+        """ Return failed security assertions logs """
+        return self._kibana.get_rows(match={"@exception.class": "Wikia\\Security\\Exception"}, limit=self.LIMIT)
+
+    def _filter(self, entry):
+        # filter out by host
+        # "@source_host": "ap-s10",
+        host = entry.get('@source_host', '')
+        if not is_production_host(host):
+            return False
+
+        return True
+
+    def _normalize(self, entry):
+        """ Normalize using the assertion class and message """
+        exception = entry.get('@exception', {})
+        source = exception.get('file')
+        caller = self._get_wikia_caller_from_exception(exception)
+
+        # @see PLATFORM-1540
+        if 'CSRFDetector' in source:
+            issue_type = 'CSRF'
+            message = 'CSRF detected in {}'.format(caller)
+        else:
+            return None
+
+        entry['issue_type'] = issue_type
+        entry['caller'] = caller
+        entry['@message'] = message
+
+        return '{}-{}-{}'.format(issue_type, issue_type, caller)
+
+    def _get_kibana_url(self, entry):
+        """
+        Get Kibana dashboard URL for a given entry
+
+        It will be automatically added at the end of the report description
+        """
+        # exception = entry.get('@exception', {})
+
+        return self.format_kibana_url(
+            query='@exception.class: "Wikia\\Security\\Exception"',
+            columns=['@timestamp', '@source_host', '@fields.url']
+        )
+
+    def _get_report(self, entry):
+        """ Format the report to be sent to JIRA """
+        context = entry.get('@context', {})
+        exception = entry.get('@exception', {})
+
+        issue_type = entry.get('issue_type')
+        message = entry.get('@message')
+        details = ''
+
+        # labels to add a report
+        labels = ['security']
+
+        assert message is not None
+
+        if issue_type == 'CSRF':
+            # @see https://cwe.mitre.org/data/definitions/352.html
+            labels.append('CWE-352')
+            details = """
+*A [Cross-site request forgery|https://cwe.mitre.org/data/definitions/352.html] attack is possible here*!
+An attacker can make a request on behalf of a current Wikia user.
+
+Please refer to [documentation on Wikia One|https://one.wikia-inc.com/wiki/User_blog:Daniel_Grunwell/Cross-Site_Request_Forgery_and_Nirvana_controllers] on how to protect your code.
+
+*Action performed*: {{{{{action_performed}}}}}
+*Token checked*: {token_checked}
+*HTTP method checked*: {method_checked}
+""".format(
+                action_performed=context.get('caller'),
+                token_checked='checked' if context.get('editTokenChecked') is True else '*not checked*',
+                method_checked='checked' if context.get('httpMethodChecked') is True else '*not checked*',
+            )
+
+        # format the report
+        full_message = self.FULL_MESSAGE_TEMPLATE.format(
+            message=message,
+            details=details.strip(),
+            backtrace=self._get_backtrace_from_exception(exception)
+        ).strip()
+
+        description = self.REPORT_TEMPLATE.format(
+            env=self._get_env_from_entry(entry),
+            source_host=entry.get('@source_host', 'n/a'),
+            context_formatted=json.dumps(entry.get('@context', {}), indent=True),
+            fields_formatted=json.dumps(entry.get('@fields', {}), indent=True),
+            full_message=full_message,
+            url=self._get_url_from_entry(entry) or 'n/a'
+        ).strip()
+
+        report = Report(
+            summary=message,
+            description=description,
+            label=self.REPORT_LABEL
+        )
+
+        # add security issue specific labels
+        [report.add_label(label) for label in labels]
+
+        return report

--- a/reporter/test/test_php_source.py
+++ b/reporter/test/test_php_source.py
@@ -17,6 +17,10 @@ class PHPLogsSourceTestClass(unittest.TestCase):
         assert PHPLogsSource._get_backtrace_from_exception({'file': '/test', 'trace': ['/foo', '/bar']}) == '* /test\n* /foo\n* /bar'
         assert PHPLogsSource._get_backtrace_from_exception({'trace': ['/usr/wikia/slot1/6875/src/includes/Hooks.php:216']}) == '* /includes/Hooks.php:216'
 
+        assert PHPLogsSource._get_backtrace_from_exception({'file': '/test', 'trace': ['/foo', '/bar']}, offset=0) == '* /test\n* /foo\n* /bar'
+        assert PHPLogsSource._get_backtrace_from_exception({'file': '/test', 'trace': ['/foo', '/bar']}, offset=1) == '* /foo\n* /bar'
+        assert PHPLogsSource._get_backtrace_from_exception({'file': '/test', 'trace': ['/foo', '/bar']}, offset=2) == '* /bar'
+
         assert PHPLogsSource._get_backtrace_from_exception({
             'file': '/usr/wikia/slot1/7211/src/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php:334',
             'trace': ['/usr/wikia/slot1/6875/src/includes/Hooks.php:216']

--- a/reporter/test/test_php_source.py
+++ b/reporter/test/test_php_source.py
@@ -21,3 +21,85 @@ class PHPLogsSourceTestClass(unittest.TestCase):
             'file': '/usr/wikia/slot1/7211/src/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php:334',
             'trace': ['/usr/wikia/slot1/6875/src/includes/Hooks.php:216']
         }) == '* /extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php:334\n* /includes/Hooks.php:216'
+
+    def test_get_wikia_caller_from_exception(self):
+        assert PHPLogsSource._get_wikia_caller_from_exception(None) is None
+        assert PHPLogsSource._get_wikia_caller_from_exception({'trace': None}) is None
+
+        assert PHPLogsSource._get_wikia_caller_from_exception({'trace': [
+            "/usr/wikia/slot1/7550/src/extensions/wikia/Security/classes/CSRFDetector.class.php:59",
+            "{\"function\":\"foo\",\"class\":\"Wikia\\\\Security\\\\CSRFDetector\",\"type\":\"::\"}",
+            "/usr/wikia/slot1/7550/src/includes/Hooks.php:216",
+            "/usr/wikia/slot1/7550/src/includes/GlobalFunctions.php:4045",
+            "/usr/wikia/slot1/7550/src/includes/upload/UploadFromUrl.php:164",
+            "/usr/wikia/slot1/7550/src/includes/upload/UploadFromUrl.php:110",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php:332",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php:282",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php:93",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php:548",
+            "/usr/wikia/slot1/7550/src/includes/wikia/services/VideoService.class.php:94",
+            "/usr/wikia/slot1/7550/src/includes/wikia/services/VideoService.class.php:58",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/VideoHandlers/VideosController.class.php:29",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatcher.class.php:205",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaApp.class.php:638",
+            "/usr/wikia/slot1/7550/src/wikia.php:48"
+        ]}) == '/extensions/wikia/VideoHandlers/VideoFileUploader.class.php:332'
+
+        assert PHPLogsSource._get_wikia_caller_from_exception({'trace': [
+            "/usr/wikia/slot1/7550/src/extensions/wikia/Security/classes/CSRFDetector.class.php:81",
+            "{\"function\":\"onUserSaveSettings\",\"class\":\"Wikia\\\\Security\\\\CSRFDetector\",\"type\":\"::\"}",
+            "/usr/wikia/slot1/7550/src/includes/Hooks.php:216",
+            "/usr/wikia/slot1/7550/src/includes/GlobalFunctions.php:4045",
+            "/usr/wikia/slot1/7550/src/includes/User.php:3567",
+            "/usr/wikia/slot1/7550/src/includes/wikia/services/UserService.class.php:71",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/FacebookClient/FacebookClientController.class.php:156",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatcher.class.php:205",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaApp.class.php:638",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatchableObject.class.php:95",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatchableObject.class.php:109",
+            "/usr/wikia/slot1/7550/src/extensions/wikia/FacebookClient/FacebookClientController.class.php:101",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatcher.class.php:205",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaApp.class.php:638",
+            "/usr/wikia/slot1/7550/src/wikia.php:48"
+        ]}) == '/extensions/wikia/FacebookClient/FacebookClientController.class.php:156'
+
+        assert PHPLogsSource._get_wikia_caller_from_exception({'trace': [
+            "/usr/wikia/slot1/7550/src/extensions/wikia/Security/classes/CSRFDetector.class.php:47",
+            "{\"function\":\"foo\",\"class\":\"Wikia\\\\Security\\\\CSRFDetector\",\"type\":\"::\"}",
+            "/usr/wikia/slot1/7550/src/includes/Hooks.php:216",
+            "/usr/wikia/slot1/7550/src/includes/GlobalFunctions.php:4045",
+            "/usr/wikia/slot1/7550/src/includes/Revision.php:1063",
+            "/usr/wikia/slot1/7550/src/includes/WikiPage.php:1464",
+            "/usr/wikia/slot1/7550/src/includes/filerepo/file/LocalFile.php:1149",
+            "/usr/wikia/slot1/7550/src/includes/filerepo/file/LocalFile.php:950",
+            "/usr/wikia/slot1/7550/src/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php:40",
+            "/usr/wikia/slot1/7550/src/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php:14",
+            "/usr/wikia/slot1/7550/src/includes/api/ApiMain.php:725",
+            "/usr/wikia/slot1/7550/src/includes/api/ApiMain.php:362",
+            "/usr/wikia/slot1/7550/src/includes/api/ApiMain.php:346",
+            "/usr/wikia/slot1/7550/src/api.php:129"
+        ]}) == '/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php:40'
+
+        assert PHPLogsSource._get_wikia_caller_from_exception({'trace': [
+            "/usr/wikia/slot1/7550/src/extensions/wikia/Security/classes/CSRFDetector.class.php:69",
+            "{\"function\":\"onUploadComplete\",\"class\":\"Wikia\\\\Security\\\\CSRFDetector\",\"type\":\"::\"}",
+            "/usr/wikia/slot1/7550/src/includes/Hooks.php:216",
+            "/usr/wikia/slot1/7550/src/includes/GlobalFunctions.php:4045",
+            "/usr/wikia/slot1/7550/src/includes/upload/UploadBase.php:624",
+            "/usr/wikia/slot1/7550/src/skins/oasis/modules/UploadPhotosController.class.php:76",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatcher.class.php:205",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaApp.class.php:638",
+            "/usr/wikia/slot1/7550/src/wikia.php:48"
+        ]}) == '/skins/oasis/modules/UploadPhotosController.class.php:76'
+
+        assert PHPLogsSource._get_wikia_caller_from_exception({'trace': [
+            "/usr/wikia/slot1/7550/src/extensions/wikia/Security/classes/CSRFDetector.class.php:81",
+            "{\"function\":\"onUserSaveSettings\",\"class\":\"Wikia\\\\Security\\\\CSRFDetector\",\"type\":\"::\"}",
+            "/usr/wikia/slot1/7550/src/includes/Hooks.php:216",
+            "/usr/wikia/slot1/7550/src/includes/GlobalFunctions.php:4045",
+            "/usr/wikia/slot1/7550/src/includes/User.php:3567",
+            "/usr/wikia/slot1/7550/src/includes/wikia/api/SendGridPostBackApiController.class.php:77",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaDispatcher.class.php:205",
+            "/usr/wikia/slot1/7550/src/includes/wikia/nirvana/WikiaApp.class.php:638",
+            "/usr/wikia/slot1/7550/src/wikia.php:48"
+        ]}) == '/includes/wikia/api/SendGridPostBackApiController.class.php:77'


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1535

Automate reporting of CSRF issues that are logged by [PLATFORM-1540](https://wikia-inc.atlassian.net/browse/PLATFORM-1540) - f817287

Not enabling it in `check.py` (only in `sandbox.py`) - waiting for more detailed logging that will go live Oct 12th.

@jcellary 