### PR TITLE
Improve UTF handling

### DIFF
--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -207,7 +207,7 @@ class KibanaSource(Source):
         url = False
         try:
             if fields.get('server') and fields.get('url'):
-                url = 'http://{}{}'.format(fields.get('server'), fields.get('url'))
+                url = 'http://{}{}'.format(fields.get('server').encode('utf8'), fields.get('url').encode('utf8'))
         except UnicodeEncodeError:
             self._logger.error('URL parsing failed', exc_info=True)
 

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -144,7 +144,7 @@ h5. Backtrace
         if message is None:
             return None
 
-        message = message.strip()
+        message = message.strip().encode('utf8')
 
         """
         A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -46,7 +46,7 @@ h5. Backtrace
         exception_class = exception.get('class')
         env = self._get_env_from_entry(entry)
 
-        message = entry.get('@message', '')
+        message = entry.get('@message', '').encode('utf8')
 
         # use a message from the exception
         if exception_class == 'WikiaException':

--- a/reporter/test/test_db_source.py
+++ b/reporter/test/test_db_source.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Set of unit tests for DBQueryErrorsSource
 """
@@ -74,6 +75,11 @@ class DBQueryErrorsSourceTestClass(unittest.TestCase):
             '@exception': {'message': 'Foo\nQuery: SELECT foo FROM bar\nFunction: FooClass::getBar'},
             '@context': {'errno': 42}
         }) == 'SELECT foo FROM bar-42'
+
+        assert source._normalize({
+            '@exception': {'message': u'Foo\nQuery: SELECT foo FROM bar WHERE ąść\nFunction: FooClass::getBar'},
+            '@context': {'errno': 42}
+        }) == 'SELECT foo FROM bar WHERE ąść-42'
 
         # SQL syntax errors (error #1064) are normalized a bit differently - PLATFORM-1512
         assert source._normalize({

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Set of unit tests for PHPErrorsSource
 """
@@ -155,14 +156,20 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         assert report.get_labels() == ['PHPErrors']
 
     def test_get_url_from_entry(self):
-        entry = {
+        assert self._source._get_url_from_entry({
             "@fields": {
                 "server": "zh.asoiaf.wikia.com",
                 "url": "/wikia.php?controller=Foo&method=bar",
             }
-        }
+        }) == 'http://zh.asoiaf.wikia.com/wikia.php?controller=Foo&method=bar'
 
-        assert self._source._get_url_from_entry(entry) == 'http://zh.asoiaf.wikia.com/wikia.php?controller=Foo&method=bar'
+        assert self._source._get_url_from_entry({
+            "@fields": {
+                "server": "zh.asoiaf.wikia.com",
+                "url": u"/wiki/Ąźć",
+            }
+        }) == 'http://zh.asoiaf.wikia.com/wiki/Ąźć'
+
         assert self._source._get_url_from_entry({}) is False
 
     def test_get_env_from_entry(self):

--- a/reporter/test/test_php_exceptions_source.py
+++ b/reporter/test/test_php_exceptions_source.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Set of unit tests for PHPExceptionsSource
 """
@@ -26,3 +27,6 @@ class PHPExceptionsSourceTestClass(unittest.TestCase):
             '@message': 'Foo',
             '@exception': {'class': 'WikiaException', 'message': 'Template file not found: /usr/wikia/slot1/6969/src/extensions/wikia/Rail/templates/RailController_LazyForAnons.php'}
         }) == 'Production-WikiaException-Template file not found: /extensions/wikia/Rail/templates/RailController_LazyForAnons.php'
+
+        # UTF handling
+        assert self._source._normalize({'@message': u'ąźć', '@exception': {'class': 'Exception'}}) == 'Production-Exception-ąźć'


### PR DESCRIPTION
Properly encode UTF strings and avoid `UnicodeEncodeError`

@jcellary 