### PR TITLE
Do not ignore deploy hosts when checking PHP logs

### DIFF
--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -8,7 +8,7 @@ def is_production_host(host):
     """
     Return true if given host is from our main datacenter (SJC) or backup datacenter (Reston)
     """
-    return re.search(r'^(ap|task|cron|liftium|staging)\-(s|r)', host) is not None
+    return re.search(r'^(ap|task|cron|liftium|staging|deploy)\-(s|r)', host) is not None
 
 
 def generalize_sql(sql):

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -17,6 +17,9 @@ class UtilsTestClass(unittest.TestCase):
         assert is_production_host('ap-r32')
         assert is_production_host('dev-foo') is False
 
+        assert is_production_host('deploy-s3')
+        assert is_production_host('deploy-r2')
+
     def test_generalize_sql(self):
         assert generalize_sql(None) is None
 


### PR DESCRIPTION
Include PHP logs emitted by deploy tools servers (running in SJC and RES) when checking PHP warnings.