### PR TITLE
Remove DOMDocument::loadHTML() errors details

### DIFF
--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -15,8 +15,8 @@ logging.basicConfig(
 
 reports = list()
 
-#source = PHPErrorsSource()
-#reports += source.query("PHP Fatal Error", threshold=5)
+source = PHPErrorsSource()
+reports += source.query("PHP Fatal Error", threshold=5)
 
 #source = KilledDatabaseQueriesSource()
 #reports += source.query(threshold=0)
@@ -34,7 +34,7 @@ reports = list()
 
 #reports += PHPExceptionsSource().query(threshold=50)
 
-reports += PHPSecuritySource().query(threshold=0)
+#reports += PHPSecuritySource().query(threshold=0)
 
 for report in reports:
     print report

--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -96,11 +96,10 @@ class PHPErrorsSource(PHPLogsSource):
         # /data/deploytools/build/wikia.foo/src
         message = re.sub(r'/data/deploytools/build/wikia.[^/]+/src', '', message)
 
-        # remove XML parsing errors details
+        # remove DOMDocument::loadHTML() errors details
         # Tag figure invalid in Entity, line: 286
         # Unexpected end tag : p in Entity, line: 82
-        message = re.sub(r'Tag \w+ invalid in Entity, line: \d+', 'Tag X invalid in Entity, line: N', message)
-        message = re.sub(r'Unexpected end tag : \w+ in Entity, line: \d+', 'Unexpected end tag : X in Entity, line: N', message)
+        message = re.sub(r'DOMDocument::loadHTML\(\): [^,]+, line: \d+', 'DOMDocument::loadHTML(): X, line: N', message)
 
         # remove popen() arguments
         message = re.sub(r'popen\([^\)]+\)', 'popen(X)', message)

--- a/reporter/test/test_kibana.py
+++ b/reporter/test/test_kibana.py
@@ -18,18 +18,18 @@ class KibanaSourceTestClass(unittest.TestCase):
         assert self._source.format_kibana_url('foo,bar') == self._source.format_kibana_url('foo bar')
 
         assert self._source.format_kibana_url('foo') == \
-               'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=foo&from=6h&fields=@timestamp,@source_host,message'
+               'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=foo&from=6h&fields=@timestamp,@source_host,@message'
 
         assert self._source.format_kibana_url('foo bar') == \
-               'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=foo%20bar&from=6h&fields=@timestamp,@source_host,message'
+               'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=foo%20bar&from=6h&fields=@timestamp,@source_host,@message'
 
         assert self._source.format_kibana_url('foo', ['@timestamp', 'name']) == \
                'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=foo&from=6h&fields=@timestamp,name'
 
         assert self._source.format_kibana_url(
             query='@exception.class: "Wikia\Security\Exception" AND @context.transaction: "foo/bar"'
-        ) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40exception.class%3A%20%22Wikia%5C%5CSecurity%5C%5CException%22%20AND%20%40context.transaction%3A%20%22foo/bar%22&from=6h&fields=@timestamp,@source_host,message'
+        ) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40exception.class%3A%20%22Wikia%5C%5CSecurity%5C%5CException%22%20AND%20%40context.transaction%3A%20%22foo/bar%22&from=6h&fields=@timestamp,@source_host,@message'
 
         assert self._source.format_kibana_url(
             query='@exception.class: "Wikia\Util\AssertionException"'
-        ) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40exception.class%3A%20%22Wikia%5C%5CUtil%5C%5CAssertionException%22&from=6h&fields=@timestamp,@source_host,message'
+        ) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40exception.class%3A%20%22Wikia%5C%5CUtil%5C%5CAssertionException%22&from=6h&fields=@timestamp,@source_host,@message'

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -46,11 +46,15 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
         # normalize "Tag figure invalid in Entity, line: 286" part
         assert self._source._normalize({
             '@message': 'PHP Warning: DOMDocument::loadHTML(): Tag figure invalid in Entity, line: 286 in /includes/wikia/InfoboxExtractor.class.php on line 53'
-        }) == 'PHP-PHP Warning: DOMDocument::loadHTML(): Tag X invalid in Entity, line: N in /includes/wikia/InfoboxExtractor.class.php on line 53-Production'
+        }) == 'PHP-PHP Warning: DOMDocument::loadHTML(): X, line: N in /includes/wikia/InfoboxExtractor.class.php on line 53-Production'
 
         assert self._source._normalize({
             '@message': 'PHP Warning: DOMDocument::loadHTML(): Unexpected end tag : p in Entity, line: 82 in /usr/wikia/slot1/8696/src/includes/wikia/parser/templatetypes/handlers/DataTables.class.php on line 81'
-        }) == 'PHP-PHP Warning: DOMDocument::loadHTML(): Unexpected end tag : X in Entity, line: N in /includes/wikia/parser/templatetypes/handlers/DataTables.class.php on line 81-Production'
+        }) == 'PHP-PHP Warning: DOMDocument::loadHTML(): X, line: N in /includes/wikia/parser/templatetypes/handlers/DataTables.class.php on line 81-Production'
+
+        assert self._source._normalize({
+            '@message': 'PHP Warning: DOMDocument::loadHTML(): Opening and ending tag mismatch: td and tr in Entity, line: 46 in /includes/wikia/parser/templatetypes/handlers/DataTables.class.php on line 81'
+        }) == 'PHP-PHP Warning: DOMDocument::loadHTML(): X, line: N in /includes/wikia/parser/templatetypes/handlers/DataTables.class.php on line 81-Production'
 
         # normalize popen() logs
         assert self._source._normalize({


### PR DESCRIPTION
Improve the way warnings like `PHP Warning: DOMDocument::loadHTML(): Opening and ending tag mismatch: td and tr in Entity, line: 46 in /includes/wikia/parser/templatetypes/handlers/DataTables.class.php on line 81` ([ER-9977](https://wikia-inc.atlassian.net/browse/ER-9977)) are normalized

And add a link to request trace based on `@fields.request_id`.