### PR TITLE
Set URL JIRA field when reporting issues

### DIFF
--- a/reporter/reporters.py
+++ b/reporter/reporters.py
@@ -63,6 +63,8 @@ class Jira(object):
         Send given report to JIRA
 
         It checks if it hasn't been reported already
+
+        :type report reporter.reports.Report
         """
         self._logger.info('Reporting "{}"'.format(report.get_summary()))
 
@@ -89,8 +91,11 @@ class Jira(object):
         # set default fields as defined in the config.py
         ticket_dict.update(self._fields['default'])
 
-        # set report_hash field
+        # set custom field
         ticket_dict[self._fields['custom']['unique_id']] = report.get_unique_id()
+
+        if report.get_url() is not False:
+            ticket_dict[self._fields['custom']['url']] = report.get_url()
 
         # report the ticket
         self._logger.info('Reporting {}'.format(json.dumps(ticket_dict)))

--- a/reporter/reporters.py
+++ b/reporter/reporters.py
@@ -91,9 +91,7 @@ class Jira(object):
         # set default fields as defined in the config.py
         ticket_dict.update(self._fields['default'])
 
-        # set custom field
-        ticket_dict[self._fields['custom']['unique_id']] = report.get_unique_id()
-
+        # set custom fields
         if report.get_url() is not False:
             ticket_dict[self._fields['custom']['url']] = report.get_url()
 

--- a/reporter/reports.py
+++ b/reporter/reports.py
@@ -15,8 +15,9 @@ class Report(object):
         if label:
             self.add_label(label)
 
-        self._unique_id = False
         self._counter = False
+        self._unique_id = False
+        self._url = False
 
     def set_unique_id(self, unique_id):
         """ Set the hash used to avoid duplicates reported to JIRA """
@@ -33,6 +34,14 @@ class Report(object):
     def get_counter(self):
         """ Get occurrences counter """
         return self._counter
+
+    def set_url(self, url):
+        """ Set URL for this report """
+        self._url = url
+
+    def get_url(self):
+        """ Get URL for this report """
+        return self._url
 
     def get_summary(self):
         """ Get report title / summary """

--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -279,3 +279,6 @@ class KibanaSource(Source):
                     query='@fields.request_id: "{}"'.format(request_id)
                 )
             ))
+
+        # set JIRA URL field
+        report.set_url(self._get_url_from_entry(entry))


### PR DESCRIPTION
@JoannaBorun added the URL custom field to tickets in ER project. Let's use this field to store the URL of the page where the report issue can be reproduced.

And as we're here, do not set `report_hash` custom field - the unique report hash is now a part of ticket description.

@jcellary 