### PR TITLE
Report PHP notices

### DIFF
--- a/reporter/bin/check.py
+++ b/reporter/bin/check.py
@@ -26,6 +26,7 @@ reports += source.query("PHP Fatal Error", threshold=5)
 reports += source.query("PHP Catchable Fatal", threshold=5)
 reports += source.query("PHP Warning", threshold=50)
 reports += source.query("PHP Strict Standards", threshold=200)
+reports += source.query("PHP Notice", threshold=2000)
 
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/Severity%20error
 reports += PHPExceptionsSource().query(threshold=50)

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -17,6 +17,7 @@ reports = list()
 
 source = PHPErrorsSource()
 #reports += source.query("PHP Fatal Error", threshold=5)
+reports += source.query("PHP Notice", threshold=2000)
 
 #source = KilledDatabaseQueriesSource()
 #reports += source.query(threshold=0)
@@ -36,7 +37,7 @@ source = PHPErrorsSource()
 
 #reports += PHPSecuritySource().query(threshold=0)
 
-reports += PhalanxSource().query(threshold=5)
+#reports += PhalanxSource().query(threshold=5)
 
 for report in reports:
     print report

--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -124,12 +124,17 @@ class PHPErrorsSource(PHPLogsSource):
 
         # normalize fatals (PLATFORM-1463)
         message = re.sub(r'PHP Fatal Error:\s+', 'PHP Fatal Error: ', message, flags=re.IGNORECASE)
+        message = re.sub(r'PHP Notice:\s+', 'PHP Notice: ', message)
 
         # remove long backtraces from error message
         message = re.sub(r'\s?Stack trace:(.*)\{main\}\s?', '', message, flags=re.MULTILINE)
 
         # remove line number from simple_html_dom.php fatal errors
         message = re.sub(r'simplehtmldom/simple_html_dom.php on line \d+', 'simplehtmldom/simple_html_dom.php', message)
+
+        # remove index name / offset from notices
+        message = re.sub(r'Undefined index: [^\s]+ in', 'Undefined index: X in', message)
+        message = re.sub(r'Undefined offset: \d+ in', 'Undefined offset: N in', message)
 
         # update the entry
         entry['@message_normalized'] = message

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -122,6 +122,15 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
             '@message': "PHP Fatal Error: Uncaught exception 'DBConnectionError' with message 'DB connection error: Unknown MySQL server host 'slave.db-sharedb.service.consul' (2) (slave.db-sharedb.service.consul)' in /usr/wikia/slot1/8369/src/includes/db/Database.php:825\nStack trace:\n#0 /usr/wikia/slot1/8369/src/includes/db/LoadBalancer.php(774): DatabaseBase->reportConnectionError('Unknown error (...')\n#1 /usr/wikia/slot1/8369/src/includes/db/LoadBalancer.php(530): LoadBalancer->reportConnectionError(Object(DatabaseMysqli))\n#2 /usr/wikia/slot1/8369/src/includes/GlobalFunctions.php(3640): LoadBalancer->getConnection(-1, Array, 'wikicities')\n#3 /usr/wikia/slot1/8369/src/extensions/wikia/WikiFactory/WikiFactory.php(169): wfGetDB(-1, Array, 'wikicities')\n#4 /usr/wikia/slot1/8369/src/extensions/wikia/WikiFactory/WikiFactory.php(2722): WikiFactory::db(-1)\n#5 /usr/wikia/slot1/8369/src/extensions/wikia/WikiFactory/WikiFactory.php(2676): WikiFactory::getCategories('530', true)\n#6 /usr/wikia/slot1/8369/config/CommonExtensions.php(94): WikiFactory::getCategory('530')\n#7 /usr/wikia/slot1/8369/config/LocalSettings.php(119): require_once('/usr/wikia/slot...')\n#8 /usr/wikia/slot1/8369/src/LocalSettings.php(4): require('/usr/wikia/slot...')\n#9 /usr/wikia/slot1/8369/src/includes/WebStart.php(141): require_once('/usr/wikia/slot...')\n#10 /usr/wikia/slot1/8369/src/wikia.php(13): require('/usr/wikia/slot...')\n#11 {main}\n  thrown in /usr/wikia/slot1/8369/src/includes/db/Database.php on line 825",
         }) == "PHP-PHP Fatal Error: Uncaught exception 'DBConnectionError' with message 'DB connection error: Unknown MySQL server host 'slave.db-sharedb.service.consul' (2) (slave.db-sharedb.service.consul)' in /includes/db/Database.php:825 thrown in /includes/db/Database.php on line 825-Production"
 
+        # remove index name / offset from "PHP Notice:  Undefined index: bio in /foo/Bar.php"
+        assert self._source._normalize({
+            '@message': 'PHP Notice:  Undefined index: twitter in /lib/Wikia/src/Service/User/Attributes/UserAttributes.php on line 154',
+        }) == 'PHP-PHP Notice: Undefined index: X in /lib/Wikia/src/Service/User/Attributes/UserAttributes.php on line 154-Production'
+
+        assert self._source._normalize({
+            '@message': 'PHP Notice: Undefined offset: 43339 in /lib/Wikia/src/Domain/User/Preferences/UserPreferences.php on line 94',
+        }) == 'PHP-PHP Notice: Undefined offset: N in /lib/Wikia/src/Domain/User/Preferences/UserPreferences.php on line 94-Production'
+
     def test_get_kibana_url(self):
         assert self._source._get_kibana_url({
             '@message': 'PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /usr/wikia/slot1/2996/src/includes/Linker.php on line 184'


### PR DESCRIPTION
We managed to keep the log of PHP fatals and exceptions quite silent for a while. Now the time has come to get rid of PHP notices (when there are more than 2000 reports an hour).

```
PHP Notice: Undefined index: X in /extensions/wikia/ArticleAsJson/ArticleAsJson.class.php on line 419 (10934 instances)
```

@jcellary 