### PR TITLE
PLATFORM-1949: Use @fields.http_url

### DIFF
--- a/reporter/sources/php/assertions.py
+++ b/reporter/sources/php/assertions.py
@@ -63,7 +63,7 @@ h5. Backtrace
 
         return self.format_kibana_url(
             query='@exception.class: "Wikia\Util\AssertionException" AND @exception.message:"{}"'.format(exception.get('message')),
-            columns=['@timestamp', '@source_host', '@fields.url']
+            columns=['@timestamp', '@source_host', '@fields.http_url']
         )
 
     def _get_report(self, entry):

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -94,7 +94,7 @@ h5. Backtrace
 
         return self.format_kibana_url(
             query='@exception.class: "DBQueryError" AND "{}"'.format(context.get('function')),
-            columns=['@timestamp', '@source_host', '@context.errno', '@context.err', '@fields.db_name', '@fields.url']
+            columns=['@timestamp', '@source_host', '@context.errno', '@context.err', '@fields.db_name', '@fields.http_url']
         )
 
     def _get_report(self, entry):

--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -65,7 +65,7 @@ class PHPErrorsSource(PHPLogsSource):
             query=urllib.quote('@source_host: {host} AND "{message}" AND "{file}"'.format(
                 host=host_regexp, message=matches.group(1).replace(',', ''), file=matches.group(2)
             )),
-            fields=','.join(['@timestamp', '@message', '@fields.url', '@source_host'])
+            fields=','.join(['@timestamp', '@message', '@fields.http_url', '@source_host'])
         )
 
     def _normalize(self, entry):
@@ -146,9 +146,9 @@ class PHPErrorsSource(PHPLogsSource):
 
     @staticmethod
     def _has_all_required_fields(entry):
-        # @fields.url is required
+        # @fields.http_url is required
         # see PLATFORM-1162
-        return entry.get('@fields', {}).get('url') is not None
+        return entry.get('@fields', {}).get('http_url') is not None
 
     def _get_report(self, entry):
         """ Format the report to be sent to JIRA """

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -83,7 +83,7 @@ h5. Backtrace
 
         return self.format_kibana_url(
             query='"{}"'.format(message),
-            columns=['@timestamp', '@source_host', '@message', '@exception.message', '@fields.db_name', '@fields.url']
+            columns=['@timestamp', '@source_host', '@message', '@exception.message', '@fields.db_name', '@fields.http_url']
         )
 
     def _get_description(self, entry):

--- a/reporter/sources/php/security.py
+++ b/reporter/sources/php/security.py
@@ -73,7 +73,7 @@ h5. Backtrace
         return self.format_kibana_url(
             query='@exception.class: "{}" AND @context.transaction: "{}" AND @context.hookName: "{}"'.
                   format(self.EXCEPTION_CLASS, transaction, hook_name),
-            columns=['@timestamp', '@source_host', '@fields.url']
+            columns=['@timestamp', '@source_host', '@fields.http_url']
         )
 
     def _get_report(self, entry):

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -134,20 +134,20 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
     def test_get_kibana_url(self):
         assert self._source._get_kibana_url({
             '@message': 'PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /usr/wikia/slot1/2996/src/includes/Linker.php on line 184'
-        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Fatal%20Error%3A%20Maximum%20execution%20time%20of%20180%20seconds%20exceeded%22%20AND%20%22/src/includes/Linker.php%20on%20line%20184%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host'
+        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Fatal%20Error%3A%20Maximum%20execution%20time%20of%20180%20seconds%20exceeded%22%20AND%20%22/src/includes/Linker.php%20on%20line%20184%22&from=6h&fields=@timestamp,@message,@fields.http_url,@source_host'
 
         assert self._source._get_kibana_url({
             '@message': 'PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /usr/wikia/slot1/2996/src/includes/Linker.php on line 184',
             '@source_host': 'task-s2'
-        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20task-s%2A%20AND%20%22PHP%20Fatal%20Error%3A%20Maximum%20execution%20time%20of%20180%20seconds%20exceeded%22%20AND%20%22/src/includes/Linker.php%20on%20line%20184%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host'
+        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20task-s%2A%20AND%20%22PHP%20Fatal%20Error%3A%20Maximum%20execution%20time%20of%20180%20seconds%20exceeded%22%20AND%20%22/src/includes/Linker.php%20on%20line%20184%22&from=6h&fields=@timestamp,@message,@fields.http_url,@source_host'
 
         assert self._source._get_kibana_url({
             '@message': 'PHP Fatal error: Call to undefined method Block::getPermissionsError() in /usr/wikia/slot1/3866/src/extensions/VisualEditor/ApiVisualEditor.php on line 449'
-        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Fatal%20error%3A%20Call%20to%20undefined%20method%20Block%3A%3AgetPermissionsError%28%29%22%20AND%20%22/src/extensions/VisualEditor/ApiVisualEditor.php%20on%20line%20449%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host'
+        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Fatal%20error%3A%20Call%20to%20undefined%20method%20Block%3A%3AgetPermissionsError%28%29%22%20AND%20%22/src/extensions/VisualEditor/ApiVisualEditor.php%20on%20line%20449%22&from=6h&fields=@timestamp,@message,@fields.http_url,@source_host'
 
         assert self._source._get_kibana_url({
             '@message': 'PHP Catchable fatal error: Argument 1 passed to ArticleService::getContentFromParser() must be an instance of ParserOutput, boolean given, called in /usr/wikia/slot1/4610/src/includes/wikia/services/ArticleService.class.php on line 192'
-        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Catchable%20fatal%20error%3A%20Argument%201%20passed%20to%20ArticleService%3A%3AgetContentFromParser%28%29%20must%20be%20an%20instance%20of%20ParserOutput%20boolean%20given%20called%22%20AND%20%22/src/includes/wikia/services/ArticleService.class.php%20on%20line%20192%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host'
+        }) == 'https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Catchable%20fatal%20error%3A%20Argument%201%20passed%20to%20ArticleService%3A%3AgetContentFromParser%28%29%20must%20be%20an%20instance%20of%20ParserOutput%20boolean%20given%20called%22%20AND%20%22/src/includes/wikia/services/ArticleService.class.php%20on%20line%20192%22&from=6h&fields=@timestamp,@message,@fields.http_url,@source_host'
 
         assert self._source._get_kibana_url({}) is None
 

--- a/reporter/test/test_source.py
+++ b/reporter/test/test_source.py
@@ -32,7 +32,7 @@ class DummySource(Source):
                 '@message': 'Foo-Bar',
                 '@context': [456, query],
                 '@fields': {
-                    'url': 'http://example.com'
+                    'http_url': 'http://example.com'
                 }
             },
             {
@@ -58,15 +58,15 @@ class DummySource(Source):
 
     @staticmethod
     def _has_all_required_fields(entry):
-        # @fields.url is required
-        return entry.get('@fields', {}).get('url') is not None
+        # @fields.http_url is required
+        return entry.get('@fields', {}).get('http_url') is not None
 
     def _get_report(self, entry):
         """ Generate Report instance for a given entry """
         self._reports_count += 1
 
         return Report(
-            summary='[Error] {msg} - {url}'.format(msg=entry.get('@message'), url=entry['@fields']['url']),
+            summary='[Error] {msg} - {url}'.format(msg=entry.get('@message'), url=entry['@fields']['http_url']),
             description=json.dumps(entry.get('@context'))
         )
 


### PR DESCRIPTION
[PLATFORM-1949](https://wikia-inc.atlassian.net/browse/PLATFORM-1949) introduced a new set of fields for logging page URL and domain. Update Jira Reporter to use them for filtering and when generating Kibana dashboard URL.

See https://github.com/Wikia/app/pull/9878 / #39

@jcellary 