### PR TITLE
Source: handle exceptions raised in _get_entries or _filter

### DIFF
--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -21,7 +21,7 @@ class Source(object):
         The Source class entry point
 
         - the provided query is passed to _get_entries method.
-        - returned entries are than filtered using _filter method.
+        - returned entries are then filtered using _filter method.
         - filtered entries are normalized using _normalize_entries method
         - reports are grouped (using the key returned by _normalize_entries)
         - each report is than formatted
@@ -31,7 +31,12 @@ class Source(object):
             self._logger.info("Query: '{}'".format(query))
 
         # filter the entries
-        entries = [entry for entry in self._get_entries(query) if self._filter(entry)]
+        try:
+            entries = [entry for entry in self._get_entries(query) if self._filter(entry)]
+        except:
+            self._logger.error('self._get_entries raised an exception', exc_info=True)
+            return []
+
         self._logger.info("Got {} entries after filtering".format(len(entries)))
 
         # group them


### PR DESCRIPTION
Prevent the following:

```
2016-04-26 11:05:26 kibana                              INFO     58 rows returned in 32 ms
Traceback (most recent call last):
  File "reporter/bin/check.py", line 36, in <module>
    reports += DBQueryErrorsSource().query(threshold=20)
  File "/opt/jira-reporter/reporter/sources/common.py", line 34, in query
    entries = [entry for entry in self._get_entries(query) if self._filter(entry)]
  File "/opt/jira-reporter/reporter/sources/php/db.py", line 48, in _filter
    additional_context = self._get_context_from_entry(entry)
  File "/opt/jira-reporter/reporter/sources/php/db.py", line 171, in _get_context_from_entry
    'error': '{} {}'.format(context.get('errno'), context.get('err', '').encode('utf-8')),
AttributeError: 'list' object has no attribute 'get'
```

@jcellary 