### PR TITLE
	PHPAssertionsSource: normalize user attributes URLs and timeout errors (ms and bytes)

### DIFF
--- a/reporter/sources/php/assertions.py
+++ b/reporter/sources/php/assertions.py
@@ -47,6 +47,10 @@ h5. Backtrace
 
         # normalize services timeout errors
         message = re.sub(r'API call to /[^ ]+ timed out', 'API call to /X timed out', message)
+        message = re.sub(r'after \d+ milliseconds with \d+ bytes', 'after N milliseconds with N bytes', message)
+
+        # normalize user attributes URLs
+        message = re.sub(r'/attr/\w+', '/attr/X', message)
 
         # {"title":"Attribute UserProfilePagesV3_birthday not found for user 26816594","status":404}
         message = re.sub(r'Attribute [^\s]+ not found for user \d+', 'Attribute X not found for user N', message)

--- a/reporter/test/test_php_assertions_source.py
+++ b/reporter/test/test_php_assertions_source.py
@@ -24,8 +24,12 @@ class PHPAssertionsSourceTestClass(unittest.TestCase):
 
         assert self._source._normalize({
             '@exception': {'message': "[404] Error connecting to the API (10.8.74.17:31440/user/28883525/attr/UserProfilePagesV3_birthday)"}
-        }) == 'None-[404] Error connecting to the API (N.N.N.N:N/user/N/attr/UserProfilePagesV3_birthday)'
+        }) == 'None-[404] Error connecting to the API (N.N.N.N:N/user/N/attr/X)'
 
         assert self._source._normalize({
             '@exception': {'message': "SASS compilation failed. Check PHP error log for more information. Error ID: qjiyzrao131pe600"}
         }) == 'None-SASS compilation failed. Check PHP error log for more information. Error ID: X'
+
+        assert self._source._normalize({
+            '@exception': {'message': "API call to 10.8.42.49:31141/user/5473454/attr/occupation failed: Operation timed out after 5003 milliseconds with 0 bytes received"}
+        }) == 'None-API call to N.N.N.N:N/user/N/attr/X failed: Operation timed out after N milliseconds with N bytes received'


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-8330

```python
        assert self._source._normalize({
            '@exception': {'message': "API call to 10.8.42.49:31141/user/5473454/attr/occupation failed: Operation timed out after 5003 milliseconds with 0 bytes received"}
        }) == 'None-API call to N.N.N.N:N/user/N/attr/X failed: Operation timed out after N milliseconds with N bytes received'
```

@garthwebb, thanks for reporting this :)