### PR TITLE
SUS-3566 | index-digest - integrate with Jira Reporter

### DIFF
--- a/reporter/bin/check.py
+++ b/reporter/bin/check.py
@@ -12,7 +12,8 @@ from reporter.sources import PHPErrorsSource, PHPExceptionsSource, DBQueryErrors
     DBQueryNoLimitSource, NotCachedWikiaApiResponsesSource, KilledDatabaseQueriesSource, \
     PHPAssertionsSource, PandoraErrorsSource, PHPSecuritySource, \
     MercurySource, HeliosSource, VignetteThumbVerificationSource, AnemometerSource, \
-    ChatLogsSource, PHPExecutionTimeoutSource, BackendSource, PHPTriggeredSource
+    ChatLogsSource, PHPExecutionTimeoutSource, BackendSource, PHPTriggeredSource, \
+    IndexDigestSource
 
 logging.basicConfig(
     level=logging.INFO,
@@ -80,6 +81,8 @@ reports += PHPExecutionTimeoutSource(period=21600).query(threshold=5)
 reports += BackendSource().query(threshold=2)
 
 reports += PHPTriggeredSource().query(threshold=1)
+
+reports += IndexDigestSource().query(threshold=1)
 
 logging.info('Reporting {} issues...'.format(len(reports)))
 reporter = Jira()

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -8,7 +8,7 @@ from reporter.reporters import Jira
 from reporter.sources import KilledDatabaseQueriesSource, PHPErrorsSource, \
     DBQueryNoLimitSource, DBQueryErrorsSource, PHPAssertionsSource, PHPExceptionsSource, \
     PandoraErrorsSource, PHPSecuritySource, MercurySource, HeliosSource, AnemometerSource, \
-    ChatLogsSource, BackendSource, PHPTriggeredSource
+    ChatLogsSource, BackendSource, PHPTriggeredSource, IndexDigestSource
 
 from reporter.classifier import Classifier
 
@@ -59,7 +59,9 @@ classifier = Classifier()
 
 #reports += BackendSource().query(threshold=1)
 
-reports += PHPTriggeredSource().query(threshold=1)
+#reports += PHPTriggeredSource().query(threshold=1)
+
+reports += IndexDigestSource().query(threshold=1)
 
 for report in reports:
     print(report)

--- a/reporter/sources/__init__.py
+++ b/reporter/sources/__init__.py
@@ -14,3 +14,4 @@ from pt_kill import KilledDatabaseQueriesSource
 from pandora import PandoraErrorsSource
 from vignette import VignetteThumbVerificationSource
 from chat import ChatLogsSource
+from indexdigest import IndexDigestSource

--- a/reporter/sources/indexdigest/__init__.py
+++ b/reporter/sources/indexdigest/__init__.py
@@ -1,0 +1,1 @@
+from .indexdigest import IndexDigestSource

--- a/reporter/sources/indexdigest/indexdigest.py
+++ b/reporter/sources/indexdigest/indexdigest.py
@@ -1,0 +1,89 @@
+import json
+
+from reporter.sources.common import KibanaSource
+from reporter.reports import Report
+
+
+class IndexDigestSource(KibanaSource):
+    """
+    Get index-digest issues that are sent via syslog
+    """
+    REPORT_TEMPLATE = """
+h1. {message}
+
+*Linter*: {type}
+*Table name*: {{{{{table}}}}}
+*Database*: {{{{{database_name}}}}} ({database_version})
+*Host*: {{{{{database_host}}}}}
+
+h3. Table schema
+
+{{code:sql}}
+{schema}
+{{code}}
+
+h3. Context
+
+{{code}}
+{context}
+{{code}}
+
+h6. Reported by {version} - https://github.com/macbre/index-digest#checks
+    """
+
+    ELASTICSEARCH_INDEX_PREFIX = 'logstash-index-digest'
+
+    # @see https://wikia-inc.atlassian.net/browse/SUS-3566
+    # https://github.com/macbre/index-digest#syslog
+    ELASTICSEARCH_QUERY = 'report.type: *'
+
+    REPORT_LABEL = 'index-digest'
+
+    def _get_entries(self, query):
+        return self._kibana.query_by_string(query=self.ELASTICSEARCH_QUERY, limit=self.LIMIT)
+
+    def _filter(self, entry):
+        """
+        Skip these reports for now
+        """
+        return entry.get('report').get('type') not in [
+            'non_utf_columns',
+            'missing_primary_index',
+        ]
+
+    def _normalize(self, entry):
+        """
+        Normalize given entry
+        """
+        return 'index-digest-{}-{}-{}'.format(
+            entry.get('meta').get('database_name'),
+            entry.get('report').get('type'),
+            entry.get('report').get('table')
+        )
+
+    def _get_report(self, entry):
+        """ Format the report to be sent to JIRA """
+        meta = entry.get('meta')
+        report = entry.get('report')
+
+        description = self.REPORT_TEMPLATE.format(
+            message=report.get('message'),
+            type=report.get('type'),
+            table=report.get('table'),
+            database_name=meta.get('database_name'),
+            database_version=meta.get('database_version'),
+            database_host=meta.get('database_host'),
+            schema=report.get('context', {}).get('schema', '-- n/a'),
+            version=meta.get('version'),
+            context=json.dumps(report.get('context'), indent=True)
+        ).strip()
+
+        _report = Report(
+            summary='{} | {}'.format(report.get('table'), report.get('message')),
+            description=description,
+            label=self.REPORT_LABEL
+        )
+
+        _report.add_label('index-digest-{}'.format(report.get('type')))
+
+        return _report


### PR DESCRIPTION
Resolves #82 

```
2018-01-02 14:22:58 IndexDigestSource                   INFO     Got 6 entries after filtering
2018-01-02 14:22:58 IndexDigestSource                   INFO     Returning 4 reports (with threshold set to 1 applied)
2018-01-02 14:22:58 IndexDigestSource                   INFO     > ab_experiment_group_ranges | "version_id" index can be removed as redundant (covered by "PRIMARY") (2 instances)
2018-01-02 14:22:58 IndexDigestSource                   INFO     > valid_tag | "valid_tag" has just a single column (1 instances)
2018-01-02 14:22:58 IndexDigestSource                   INFO     > page_restrictions | "pr_page" index can be removed as redundant (covered by "PRIMARY") (1 instances)
2018-01-02 14:22:58 IndexDigestSource                   INFO     > global_watchlist | "user_id" index can be removed as redundant (covered by "user_city_id") (2 instances)
```

Example report in https://wikia-inc.atlassian.net/browse/SUS-3566