### PR TITLE
SUS-5138 | Report methods performing queries on database master when handling GET requests

### DIFF
--- a/reporter/bin/check.py
+++ b/reporter/bin/check.py
@@ -13,7 +13,7 @@ from reporter.sources import PHPErrorsSource, PHPExceptionsSource, DBQueryErrors
     PHPAssertionsSource, PandoraErrorsSource, PHPSecuritySource, \
     MercurySource, HeliosSource, VignetteThumbVerificationSource, AnemometerSource, \
     ChatLogsSource, PHPExecutionTimeoutSource, BackendSource, PHPTriggeredSource, \
-    IndexDigestSource, ReportsPipeSource
+    IndexDigestSource, ReportsPipeSource, DBReadQueryOnMaster
 
 logging.basicConfig(
     level=logging.INFO,
@@ -85,6 +85,8 @@ reports += PHPTriggeredSource().query(threshold=1)
 reports += IndexDigestSource().query(threshold=1)
 
 reports += ReportsPipeSource().query(threshold=1)
+
+reports += DBReadQueryOnMaster().query(threshold=1)
 
 logging.info('Reporting {} issues...'.format(len(reports)))
 reporter = Jira()

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -8,7 +8,8 @@ from reporter.reporters import Jira
 from reporter.sources import KilledDatabaseQueriesSource, PHPErrorsSource, \
     DBQueryNoLimitSource, DBQueryErrorsSource, PHPAssertionsSource, PHPExceptionsSource, \
     PandoraErrorsSource, PHPSecuritySource, MercurySource, HeliosSource, AnemometerSource, \
-    ChatLogsSource, BackendSource, PHPTriggeredSource, IndexDigestSource, ReportsPipeSource
+    ChatLogsSource, BackendSource, PHPTriggeredSource, IndexDigestSource, ReportsPipeSource, \
+    DBReadQueryOnMaster
 
 from reporter.classifier import Classifier
 
@@ -41,7 +42,7 @@ classifier = Classifier()
 #reports += PHPExceptionsSource().query(query='error', threshold=50)
 #reports += PHPExceptionsSource().query(query='critical', threshold=0)
 
-reports += PHPSecuritySource().query(threshold=0)
+#reports += PHPSecuritySource().query(threshold=0)
 
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/PLATFORM-2055
 #reports += MercurySource().query('fatal', threshold=0)
@@ -64,6 +65,8 @@ reports += PHPSecuritySource().query(threshold=0)
 #reports += IndexDigestSource().query(threshold=1)
 
 #reports += ReportsPipeSource().query(threshold=1)
+
+reports += DBReadQueryOnMaster().query(threshold=1)
 
 for report in reports:
     print(report)

--- a/reporter/sources/php/__init__.py
+++ b/reporter/sources/php/__init__.py
@@ -1,6 +1,6 @@
 # expose all PHP-related sources
 from .assertions import PHPAssertionsSource
-from .db import DBQueryErrorsSource, DBQueryNoLimitSource
+from .db import DBQueryErrorsSource, DBQueryNoLimitSource, DBReadQueryOnMaster
 from .errors import PHPErrorsSource
 from .exceptions import PHPExceptionsSource
 from .security import PHPSecuritySource


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5133

```
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     Returning 14 reports (with threshold set to 1 applied)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [WikiFactory::getVariables] The database query should be moved to slave or an offline task (1 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [WikiFactory::setVarById] The database query should be moved to slave or an offline task (3 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [User::saveSettings] The database query should be moved to slave or an offline task (1 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [WikiFactory::loadVariableFromDB (from WikiaBarDataModel:getData)] The database query should be moved to slave or an offline task (1 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [FounderProgressBarController::getLongTaskList] The database query should be moved to slave or an offline task (4 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [wfClearWikiaNewtalk] The database query should be moved to slave or an offline task (4 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [WikiFactory::getWikiByDB] The database query should be moved to slave or an offline task (554 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [FounderEmails::processEvents] The database query should be moved to slave or an offline task (2 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [WikiFactory::clearCache] The database query should be moved to slave or an offline task (2 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [FounderProgressBarController::doTask] The database query should be moved to slave or an offline task (4 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [User::loadFromDatabase] The database query should be moved to slave or an offline task (3840 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [WikiFactory::getDomains] The database query should be moved to slave or an offline task (2 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [HealthController:testHostRW] The database query should be moved to slave or an offline task (2 instances)
2018-06-08 10:24:48 DBReadQueryOnMaster                 INFO     > [Wikia\Service\User\Permissions\PermissionsService::loadGlobalUserGroups] The database query should be moved to slave or an offline task (572 instances)
```