### PR TITLE
PHPErrorsSource: normalize memcache client errors

### DIFF
--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -145,6 +145,10 @@ class PHPErrorsSource(PHPLogsSource):
         # remove PID from "Error while sending QUERY packet." warnings
         message = re.sub(r'Error while sending \w+ packet. PID=\d+', 'Error while sending X packet. PID=N', message)
 
+        # FD_SETSIZE.It is set to 1024, but you have descriptors numbered at least as high as 2279.
+        message = re.sub(r'descriptors numbered at least as high as \d+', 'descriptors numbered at least as high as N', message)
+        message = re.sub(r'--enable-fd-setsize=\d+', '--enable-fd-setsize=N', message)
+
         # update the entry
         entry['@message_normalized'] = message
 

--- a/reporter/test/test_php_errors_source.py
+++ b/reporter/test/test_php_errors_source.py
@@ -139,6 +139,15 @@ class PHPErrorsSourceTestClass(unittest.TestCase):
             '@message': 'PHP Warning:  Error while sending QUERY packet. PID=21637 in /includes/db/DatabaseMysqli.php on line 44',
         }) == 'PHP-PHP Warning:  Error while sending X packet. PID=N in /includes/db/DatabaseMysqli.php on line 44-Production'
 
+        assert self._source._normalize({
+            '@message': 'PHP Warning: stream_select(): You MUST recompile PHP with a larger value of FD_SETSIZE.\n'
+            'It is set to 1024, but you have descriptors numbered at least as high as 2279.\n'
+            ' --enable-fd-setsize=3072 is recommended, but you may want to set it\n'
+            'to equal the maximum number of open files supported by your system,\n'
+            'in order to avoid seeing this error again at a later date. in '
+            '/usr/wikia/slot1/23724/src/includes/objectcache/MemcachedClient.php on line 1359',
+        }) == 'PHP-PHP Warning: stream_select(): You MUST recompile PHP with a larger value of FD_SETSIZE.It is set to 1024, but you have descriptors numbered at least as high as N. --enable-fd-setsize=N is recommended, but you may want to set itto equal the maximum number of open files supported by your system,in order to avoid seeing this error again at a later date. in /includes/objectcache/MemcachedClient.php on line 1359-Production'
+
     def test_get_kibana_url(self):
         assert self._source._get_kibana_url({
             '@message': 'PHP Fatal Error: Maximum execution time of 180 seconds exceeded in /usr/wikia/slot1/2996/src/includes/Linker.php on line 184'


### PR DESCRIPTION
```
PHP Warning: stream_select(): You MUST recompile PHP with a larger value of FD_SETSIZE.
It is set to 1024, but you have descriptors numbered at least as high as 2279.
 --enable-fd-setsize=3072 is recommended, but you may want to set it
to equal the maximum number of open files supported by your system,
in order to avoid seeing this error again at a later date. in /usr/wikia/slot1/23724/src/includes/objectcache/MemcachedClient.php on line 1359
```