### PR TITLE
SUS-5451 | handle logs from Kubernetes

### DIFF
--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -4,11 +4,19 @@ Set of helper functions
 import re
 
 
-def is_production_host(host):
+def is_from_production_host(entry):
     """
     Return true if given host is from our main datacenter (SJC) or backup datacenter (Reston)
+
+    Handles both string value taken from @source_host or the entire entry from logs
+
+    :type host str|object
+    :rtype: bool
     """
-    return re.search(r'^(ap|task|cron|job|liftium|staging|deploy|auth|staging-(ap|task))\-(s|r)', host) is not None
+    if isinstance(entry, str):
+        return re.search(r'^(ap|task|cron|job|liftium|staging|deploy|auth|staging-(ap|task))\-(s|r)', entry) is not None
+    else:
+        return entry.get('@fields', {}).get('environment') in ['prod', 'preview', 'verify']
 
 
 def generalize_sql(sql):

--- a/reporter/sources/backend/backend.py
+++ b/reporter/sources/backend/backend.py
@@ -2,7 +2,7 @@ import json
 import re
 
 from reporter.sources.common import KibanaSource
-from reporter.helpers import is_production_host, generalize_sql
+from reporter.helpers import is_from_production_host, generalize_sql
 from reporter.reports import Report
 
 
@@ -40,7 +40,7 @@ h3. The Camel says "{{{{{full_message}}}}}"
         host = entry.get('@source_host', '')
 
         # errors will most likely come from job-s1
-        if not is_production_host(host):
+        if not is_from_production_host(host):
             return False
 
         return True

--- a/reporter/sources/caching.py
+++ b/reporter/sources/caching.py
@@ -36,13 +36,7 @@ curl -svo /dev/null "{url}"
 
     def _filter(self, entry):
         """ Remove log entries that are not coming from main DC Apache servers """
-        # filter out by host
-        # "@source_host": "ap-s10",
-        host = entry.get('@source_host', '')
-        if not host.startswith('ap-') or not is_from_production_host(host):
-            return False
-
-        return True
+        return is_from_production_host(entry)
 
     def _normalize(self, entry):
         """ Normalize the entry using the controller and method names """

--- a/reporter/sources/caching.py
+++ b/reporter/sources/caching.py
@@ -4,7 +4,7 @@ Report caching related problems
 
 from common import KibanaSource
 
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 from reporter.reports import Report
 
 
@@ -39,7 +39,7 @@ curl -svo /dev/null "{url}"
         # filter out by host
         # "@source_host": "ap-s10",
         host = entry.get('@source_host', '')
-        if not host.startswith('ap-') or not is_production_host(host):
+        if not host.startswith('ap-') or not is_from_production_host(host):
             return False
 
         return True

--- a/reporter/sources/helios.py
+++ b/reporter/sources/helios.py
@@ -9,7 +9,7 @@ import re
 from common import KibanaSource
 
 from reporter.reports import Report
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 
 
 class HeliosSource(KibanaSource):
@@ -34,7 +34,7 @@ h3. {message}
                 limit=self.LIMIT)
 
     def _filter(self, entry):
-        if not is_production_host(entry.get('@source_host')):
+        if not is_from_production_host(entry.get('@source_host')):
             return False
 
         return True

--- a/reporter/sources/php/assertions.py
+++ b/reporter/sources/php/assertions.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 from reporter.reports import Report
 
 from common import PHPLogsSource
@@ -28,13 +28,7 @@ h5. Backtrace
         return self._kibana.get_rows(match={"@exception.class": "Wikia\\Util\\AssertionException"}, limit=self.LIMIT)
 
     def _filter(self, entry):
-        # filter out by host
-        # "@source_host": "ap-s10",
-        host = entry.get('@source_host', '')
-        if not is_production_host(host):
-            return False
-
-        return True
+        return is_from_production_host(entry)
 
     def _normalize(self, entry):
         """ Normalize using the assertion class and message """

--- a/reporter/sources/php/db.py
+++ b/reporter/sources/php/db.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from reporter.helpers import generalize_sql, is_production_host
+from reporter.helpers import generalize_sql, is_from_production_host
 from reporter.reports import Report
 
 from common import PHPLogsSource
@@ -43,12 +43,8 @@ h3. Backtrace
         return self._kibana.get_rows(match={"@exception.class": 'DBQueryError'}, limit=self.LIMIT)
 
     def _filter(self, entry):
-        """ Remove log entries that are not coming from main DC """
-        host = entry.get('@source_host', '')
-
-        # filter out by host
-        # "@source_host": "ap-s10",
-        if not is_production_host(host):
+        """ Remove log entries that are not coming from production datacenters """
+        if not is_from_production_host(entry):
             return False
 
         context = entry.get('@context', {})
@@ -251,10 +247,7 @@ h5. Backtrace
         )
 
     def _filter(self, entry):
-        # filter out by host
-        # "@source_host": "ap-s10",
-        host = entry.get('@source_host', '')
-        if not is_production_host(host):
+        if not is_from_production_host(entry):
             return False
 
         # remove those that do not return enough rows

--- a/reporter/sources/php/errors.py
+++ b/reporter/sources/php/errors.py
@@ -2,7 +2,7 @@ import json
 import re
 import urllib
 
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 from reporter.reports import Report
 
 from common import PHPLogsSource
@@ -18,13 +18,10 @@ class PHPErrorsSource(PHPLogsSource):
 
     def _filter(self, entry):
         """ Remove log entries that are not coming from main DC or lack key information """
-        message = entry.get('@message', '')
-        host = entry.get('@source_host', '')
-
-        # filter out by host
-        # "@source_host": "ap-s10",
-        if not is_production_host(host):
+        if not is_from_production_host(entry):
             return False
+
+        message = entry.get('@message', '')
 
         # filter out errors without a clear context
         # on line 115

--- a/reporter/sources/php/exceptions.py
+++ b/reporter/sources/php/exceptions.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 from reporter.reports import Report
 
 from common import PHPLogsSource
@@ -36,10 +36,7 @@ h5. Backtrace
         )
 
     def _filter(self, entry):
-        # filter out by host
-        # "@source_host": "ap-s10",
-        host = entry.get('@source_host', '')
-        if not is_production_host(host):
+        if not is_from_production_host(entry):
             return False
 
         # ignore PHP Fatal errors with backtrace here - they're handled by PHPErrorsSource
@@ -153,13 +150,7 @@ class PHPTypeErrorsSource(PHPLogsSource):
         return self._kibana.query_by_string(query='@exception.class: "TypeError"', limit=self.LIMIT)
 
     def _filter(self, entry):
-        # filter out by host
-        # "@source_host": "ap-s10",
-        host = entry.get('@source_host', '')
-        if not is_production_host(host):
-            return False
-
-        return True
+        return is_from_production_host(entry)
 
     def _normalize(self, entry):
         """ Normalize using the exception class and message """

--- a/reporter/sources/php/execution_timeouts.py
+++ b/reporter/sources/php/execution_timeouts.py
@@ -1,4 +1,4 @@
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 from reporter.reports import Report
 from common import PHPLogsSource
 
@@ -26,7 +26,7 @@ The below URL is taking too much time to render. This is usually caused by extre
         )
 
     def _filter(self, entry):
-        return is_production_host(entry.get('@source_host', ''))
+        return is_from_production_host(entry)
 
     def _normalize(self, entry):
         url = self._get_url_from_entry(entry)

--- a/reporter/sources/php/security.py
+++ b/reporter/sources/php/security.py
@@ -1,6 +1,6 @@
 import json
 
-from reporter.helpers import is_production_host
+from reporter.helpers import is_from_production_host
 from reporter.reports import Report
 
 from common import PHPLogsSource
@@ -31,13 +31,7 @@ h5. Backtrace
         return self._kibana.get_rows(match={"@exception.class": self.EXCEPTION_CLASS}, limit=self.LIMIT)
 
     def _filter(self, entry):
-        # filter out by host
-        # "@source_host": "ap-s10",
-        host = entry.get('@source_host', '')
-        if not is_production_host(host):
-            return False
-
-        return True
+        return is_from_production_host(entry)
 
     def _normalize(self, entry):
         """ Normalize using the assertion class and message """

--- a/reporter/sources/php/triggers.py
+++ b/reporter/sources/php/triggers.py
@@ -1,6 +1,3 @@
-import json
-
-from reporter.helpers import is_production_host
 from reporter.reports import Report
 
 from common import PHPLogsSource

--- a/reporter/test/test_db_source.py
+++ b/reporter/test/test_db_source.py
@@ -15,15 +15,12 @@ class DBQueryErrorsSourceTestClass(unittest.TestCase):
         source = DBQueryErrorsSource()
 
         # filter by source host
-        assert source._filter({'@source_host': 'ap-s20'}) is True
-        assert source._filter({'@source_host': 'staging-ap-s1'}) is True
-        assert source._filter({'@source_host': 'staging-task-s1'}) is True
-        assert source._filter({'@source_host': 'dev-foo'}) is False
+        assert source._filter({'@fields': {'environment': 'prod'}}) is True
 
         # filter by MySQL error codes
-        assert source._filter({'@source_host': 'ap-s20', '@context': {'errno': 1200}}) is True
-        assert source._filter({'@source_host': 'ap-s20', '@context': {'errno': 1205}}) is False
-        assert source._filter({'@source_host': 'ap-s20', '@context': {'errno': 1213}}) is False
+        assert source._filter({'@fields': {'environment': 'prod'}, '@context': {'errno': 1200}}) is True
+        assert source._filter({'@fields': {'environment': 'prod'}, '@context': {'errno': 1205}}) is False
+        assert source._filter({'@fields': {'environment': 'prod'}, '@context': {'errno': 1213}}) is False
 
         # filter out "Query execution was interrupted" errors coming from SMW and DPL
         cases = (
@@ -42,7 +39,7 @@ class DBQueryErrorsSourceTestClass(unittest.TestCase):
     @staticmethod
     def _check_is_filtered_out(function, err_no, expected):
         assert DBQueryErrorsSource()._filter({
-            '@source_host': 'ap-s20',
+            '@fields': {'environment': 'prod'},
             '@context': {'errno': err_no},
             '@exception': {'message': 'Foo\nQuery: SELECT foo FROM bar\nFunction: {}'.format(function)}
         }) is expected

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -3,29 +3,40 @@ Set of unit tests for helper functions
 """
 import unittest
 
-from ..helpers import is_production_host, generalize_sql, get_method_from_query
+from ..helpers import is_from_production_host, generalize_sql, get_method_from_query
 
 
 class UtilsTestClass(unittest.TestCase):
     @staticmethod
     def test_is_main_dc_host():
-        assert is_production_host('ap-s32')
-        assert is_production_host('task-s2')
-        assert is_production_host('cron-s1')
-        assert is_production_host('job-s1')
+        assert is_from_production_host('ap-s32')
+        assert is_from_production_host('task-s2')
+        assert is_from_production_host('cron-s1')
+        assert is_from_production_host('job-s1')
 
         # preview env
-        assert is_production_host('staging-s1')
+        assert is_from_production_host('staging-s1')
 
         # new staging
-        assert is_production_host('staging-ap-s1')
-        assert is_production_host('staging-task-s1')
+        assert is_from_production_host('staging-ap-s1')
+        assert is_from_production_host('staging-task-s1')
 
-        assert is_production_host('ap-r32')
-        assert is_production_host('dev-foo') is False
+        assert is_from_production_host('ap-r32')
+        assert is_from_production_host('dev-foo') is False
 
-        assert is_production_host('deploy-s3')
-        assert is_production_host('deploy-r2')
+        assert is_from_production_host('deploy-s3')
+        assert is_from_production_host('deploy-r2')
+
+        # new handling
+        assert is_from_production_host({'@fields': {'environment': 'prod'}})
+        assert is_from_production_host({'@fields': {'environment': 'verify'}})
+        assert is_from_production_host({'@fields': {'environment': 'preview'}})
+
+        assert is_from_production_host({'@fields': {'environment': 'sandbox'}}) is False
+        assert is_from_production_host({}) is False
+
+        # we should ignore source_host and just rely on an environment data
+        assert is_from_production_host({'@source_host': 'ap-s32'}) is False
 
     def test_generalize_sql(self):
         assert generalize_sql(None) is None

--- a/reporter/test/test_php_exceptions_source.py
+++ b/reporter/test/test_php_exceptions_source.py
@@ -44,10 +44,10 @@ class PHPExceptionsSourceTestClass(unittest.TestCase):
         assert self._source._normalize({'@message': 'Foo', '@exception': {'class': 'WikiaException', 'message': u'ąźć'}}) == 'Production-WikiaException-ąźć'
 
     def test_filter(self):
-        assert self._source._filter({'@message': 'Foo', '@source_host': 'ap-s10'}) is True
+        assert self._source._filter({'@message': 'Foo', '@fields': {'environment': 'prod'}}) is True
 
         # PHP Fatal errors with the exception backtrace should be ignored
-        assert self._source._filter({'@message': 'PHP Fatal error: Maximum execution', "@exception": {"class": "Exception"}, '@source_host': 'ap-s10'}) is False
+        assert self._source._filter({'@message': 'PHP Fatal error: Maximum execution', "@exception": {"class": "Exception"}, '@fields': {'environment': 'prod'}}) is False
 
 
 class PHPTypeErrorsSourceTestClass(unittest.TestCase):


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5451

Use `@fields.environment` to check if a log entry comes from production / verify / preview instead of checking `@source_host` (which is not set when MediaWiki logs from Kubernetes).