### PR TITLE
Helios: fix how logs are analysed

### DIFF
--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -49,7 +49,7 @@ classifier = Classifier()
 #reports += MercurySource().query('error', threshold=50)
 
 # @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/Helios%20errors
-#reports += HeliosSource().query(threshold=0)
+reports += HeliosSource().query(threshold=0)
 
 # @see https://wikia-inc.atlassian.net/browse/PLATFORM-2180
 #reports += AnemometerSource().query(threshold=0)
@@ -68,7 +68,7 @@ classifier = Classifier()
 
 #reports += DBReadQueryOnMaster().query(threshold=1)
 
-reports += PHPTypeErrorsSource().query(threshold=5)
+#reports += PHPTypeErrorsSource().query(threshold=5)
 
 for report in reports:
     print(report)

--- a/reporter/helpers.py
+++ b/reporter/helpers.py
@@ -6,17 +6,20 @@ import re
 
 def is_from_production_host(entry):
     """
-    Return true if given host is from our main datacenter (SJC) or backup datacenter (Reston)
+    Return true if a log entry comes from one of our production datacenters
 
     Handles both string value taken from @source_host or the entire entry from logs
 
-    :type host str|object
+    :type entry str|dict
     :rtype: bool
     """
     if isinstance(entry, str):
         return re.search(r'^(ap|task|cron|job|liftium|staging|deploy|auth|staging-(ap|task))\-(s|r)', entry) is not None
     else:
-        return entry.get('@fields', {}).get('environment') in ['prod', 'preview', 'verify']
+        # MediaWiki: @fields.environment   prod
+        # Kubernetes: kubernetes.namespace_name	       	prod
+        return entry.get('@fields', {}).get('environment') in ['prod', 'preview', 'verify'] or \
+               entry.get('kubernetes', {}).get('namespace_name') == 'prod'
 
 
 def generalize_sql(sql):

--- a/reporter/sources/helios.py
+++ b/reporter/sources/helios.py
@@ -4,7 +4,6 @@ Report issues from Helios service
 @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/Helios%20errors
 """
 import json
-import re
 
 from common import KibanaSource
 
@@ -30,20 +29,14 @@ h3. {message}
 
     def _get_entries(self, query):
         return self._kibana.query_by_string(
-                query='severity:"error"',
+                query='level:"error"',
                 limit=self.LIMIT)
 
     def _filter(self, entry):
-        if not is_from_production_host(entry.get('@source_host')):
-            return False
-
-        return True
+        return is_from_production_host(entry)
 
     def _normalize(self, entry):
         message = entry.get('@message')
-
-        # normalize SQL errors
-        message = re.sub(r'Duplicate entry \'[^\']+\' for key \'\w+\'', "Duplicate entry 'X' for key 'X'", message)
 
         return '{}-{}'.format(self.REPORT_LABEL, message)
 
@@ -55,7 +48,7 @@ h3. {message}
             query='@message: "{message}"'.format(
                 message=entry.get('@message')
             ),
-            columns=['@timestamp', '@source_host', '@message']
+            columns=['@timestamp', '@message']
         )
 
     def _get_report(self, entry):

--- a/reporter/test/test_helios_source.py
+++ b/reporter/test/test_helios_source.py
@@ -15,17 +15,10 @@ class HeliosSourceTestClass(unittest.TestCase):
 
     def test_filter(self):
         # prod
-        assert self._source._filter({'@source_host': 'auth-s1'}) is True
-        assert self._source._filter({'@source_host': 'auth-r1'}) is True
-
-        # dev - skip for now
-        assert self._source._filter({'@source_host': 'dev-auth-s1'}) is False
+        assert self._source._filter({'kubernetes': {'namespace_name': 'prod'}}) is True
+        assert self._source._filter({'kubernetes': {'namespace_name': 'dev'}}) is False
 
     def test_normalize(self):
         assert self._source._normalize({
             '@message': 'foo',
         }) == 'Helios-foo'
-
-        assert self._source._normalize({
-            '@message': "Error 1062: Duplicate entry '27788246-112328095453510' for key 'user_id'"
-        }) == "Helios-Error 1062: Duplicate entry 'X' for key 'X'"

--- a/reporter/test/test_helpers.py
+++ b/reporter/test/test_helpers.py
@@ -35,6 +35,10 @@ class UtilsTestClass(unittest.TestCase):
         assert is_from_production_host({'@fields': {'environment': 'sandbox'}}) is False
         assert is_from_production_host({}) is False
 
+        # kubernetes
+        assert is_from_production_host({'kubernetes': {'namespace_name': 'prod'}}) is True
+        assert is_from_production_host({'kubernetes': {'namespace_name': 'dev'}}) is False
+
         # we should ignore source_host and just rely on an environment data
         assert is_from_production_host({'@source_host': 'ap-s32'}) is False
 


### PR DESCRIPTION
Helios now runs on Kubernetes - use a different Elastic Search query to get the logs.