### PR TITLE
SUS-5480 | Error reporter should include service name when matching failure logs

### DIFF
--- a/reporter/sources/pandora/errors.py
+++ b/reporter/sources/pandora/errors.py
@@ -55,6 +55,7 @@ class PandoraErrorsSource(PandoraLogsSource):
         """
         message = entry.get('rawMessage').encode('utf8')
         logger_name = entry.get('logger_name')
+        app_name = entry.get('appname')
 
         # normalize hashes
         message = re.sub(r'[a-f0-9-]{4,}', 'HASH', message)
@@ -70,7 +71,7 @@ class PandoraErrorsSource(PandoraLogsSource):
         # error while sending: {"args":{"prevRevision":false
         message = re.sub(r'{.*}$', '{json here}', message)
 
-        return 'Pandora-{}-{}'.format(message, logger_name)
+        return 'Pandora-{}-{}-{}'.format(message, logger_name, app_name)
 
     def _get_report(self, entry):
         """ Format the report to be sent to JIRA """

--- a/reporter/test/test_pandora_errors_source.py
+++ b/reporter/test/test_pandora_errors_source.py
@@ -16,48 +16,57 @@ class PandoraErrorsSourceTestClass(unittest.TestCase):
     def test_normalize(self):
         assert self._source._normalize({
             'rawMessage': 'foo',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-foo-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-foo-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'foo 123',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-foo N-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-foo N-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'Exception purging https://services.wikia.com/user-attribute/user/5430694',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-Exception purging <URL>-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-Exception purging <URL>-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'Exception purging http://example.com',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-Exception purging <URL>-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-Exception purging <URL>-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'error while sending: {"args":{"prevRevision":false,"revision":66213},"is_main_page":false}',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-error while sending: {json here}-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-error while sending: {json here}-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'too much data after closed for HttpChannelOverHttp@276b8295{r=1,c=false,a=IDLE,uri=-}',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-too much data after closed for HttpChannelOverHttp@HASH{json here}-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-too much data after closed for HttpChannelOverHttp@HASH{json here}-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'Read timed out reading GET http://dailylifewithamonstergirl.wikia.com/wiki/Centorea_Shianus?action=raw',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-Read timed out reading GET <URL>-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-Read timed out reading GET <URL>-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': 'Site/Shard map invalid or missing entry for site 831',
-            'logger_name': 'service.foo'
-        }) == 'Pandora-Site/Shard map invalid or missing entry for site N-service.foo'
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == 'Pandora-Site/Shard map invalid or missing entry for site N-lib.foo-Service'
 
         assert self._source._normalize({
             'rawMessage': "Context property 'correlation ID' is missing from the Rabbit message, falling back to 'c2faca50-9106-4b7d-bfd3-5c3fd27e83b9'",
-            'logger_name': 'service.foo'
-        }) == "Pandora-Context property 'correlation ID' is missing from the Rabbit message, falling back to 'HASH'-service.foo"
+            'logger_name': 'lib.foo',
+            'appname': 'Service'
+        }) == "Pandora-Context property 'correlation ID' is missing from the Rabbit message, falling back to 'HASH'-lib.foo-Service"
 
     def test_kibana_url(self):
         source = PandoraErrorsSource()


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5480

The following tickets will be reported:

```
...
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [geoip] Unable to report to InfluxDB with error 'Server returned HTTP response code: 400 for URL: http://prod.os-metrics-db.service.sjc.consul:8086/write?db=services&precision=m with content :'Bad Request''. Discarding data. (600 instances)
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [user-registration-feed] Unable to report to InfluxDB with error 'Server returned HTTP response code: 400 for URL: http://dev.os-metrics-db.service.poz-dev.consul:8086/write?db=services&precision=m with content :'Bad Request''. Discarding data. (118 instances)
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [external-auth] Facebook access token validation failed. (37 instances)
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [external-auth] Unable to report to InfluxDB with error 'Server returned HTTP response code: 400 for URL: http://dev.os-metrics-db.service.poz-dev.consul:8086/write?db=services&precision=m with content :'Bad Request''. Discarding data. (599 instances)
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [content-graph-service] Unable to report to InfluxDB with error 'Server returned HTTP response code: 400 for URL: http://dev.os-metrics-db.service.sjc-dev.consul:8086/write?db=services&precision=m with content :'Bad Request''. Discarding data. (540 instances)
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [site-attribute] Unable to report to InfluxDB with error 'Server returned HTTP response code: 400 for URL: http://prod.os-metrics-db.service.sjc.consul:8086/write?db=services&precision=m with content :'Bad Request''. Discarding data. (599 instances)
2018-07-06 09:52:08 PandoraErrorsSource                 INFO     > [dc-file-sync] Unable to report to InfluxDB with error 'Server returned HTTP response code: 400 for URL: http://prod.os-metrics-db.service.sjc.consul:8086/write?db=services&precision=m with content :'Bad Request''. Discarding data. (600 instances)
...
```