### PR TITLE
SUS-1773 | improve index_digest reports normalisation

### DIFF
--- a/reporter/sources/indexdigest/indexdigest.py
+++ b/reporter/sources/indexdigest/indexdigest.py
@@ -49,10 +49,11 @@ h6. Reported by {version} - https://github.com/macbre/index-digest#checks
         """
         Normalize given entry
         """
-        return 'index-digest-{}-{}-{}'.format(
+        return 'index-digest-{}-{}-{}-{}'.format(
             entry.get('meta').get('database_name'),
             entry.get('report').get('type'),
-            entry.get('report').get('table')
+            entry.get('report').get('table'),
+            entry.get('report').get('message'),
         )
 
     def _get_report(self, entry):

--- a/reporter/sources/indexdigest/indexdigest.py
+++ b/reporter/sources/indexdigest/indexdigest.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from reporter.sources.common import KibanaSource
 from reporter.reports import Report
@@ -49,11 +50,14 @@ h6. Reported by {version} - https://github.com/macbre/index-digest#checks
         """
         Normalize given entry
         """
+        message = entry.get('report').get('message')
+        message = re.sub(r'\d+ days ago', 'N days ago', message)
+
         return 'index-digest-{}-{}-{}-{}'.format(
             entry.get('meta').get('database_name'),
             entry.get('report').get('type'),
             entry.get('report').get('table'),
-            entry.get('report').get('message'),
+            message,
         )
 
     def _get_report(self, entry):

--- a/reporter/test/test_indexdigest.py
+++ b/reporter/test/test_indexdigest.py
@@ -1,0 +1,27 @@
+"""
+Set of unit tests for IndexDigestSource
+"""
+import unittest
+
+from ..sources import IndexDigestSource
+
+
+class IndexDigestSourceTestClass(unittest.TestCase):
+    """
+    Unit tests for IndexDigestSource class
+    """
+    def setUp(self):
+        self._source = IndexDigestSource()
+
+    def test_normalize(self):
+        assert self._source._normalize({
+            'report': {
+                'message': '"user_id" index can be removed as redundant (covered by "user_wiki_preference")',
+                'table': 'local_preference',
+                'type': 'redundant_indices',
+            },
+            'meta': {
+                'database_name': 'user_preferences',
+            }
+        }) == 'index-digest-user_preferences-redundant_indices-local_preference-"user_id" ' \
+              'index can be removed as redundant (covered by "user_wiki_preference")'

--- a/reporter/test/test_indexdigest.py
+++ b/reporter/test/test_indexdigest.py
@@ -25,3 +25,15 @@ class IndexDigestSourceTestClass(unittest.TestCase):
             }
         }) == 'index-digest-user_preferences-redundant_indices-local_preference-"user_id" ' \
               'index can be removed as redundant (covered by "user_wiki_preference")'
+
+        assert self._source._normalize({
+            'report': {
+                'message': '"cu_log" has rows added 3726 days ago, consider changing retention policy',
+                'table': 'local_preference',
+                'type': 'redundant_indices',
+            },
+            'meta': {
+                'database_name': 'user_preferences',
+            }
+        }) == 'index-digest-user_preferences-redundant_indices-local_preference-"cu_log" has rows added ' \
+              'N days ago, consider changing retention policy'


### PR DESCRIPTION
Take report message into account, this improves reporting of duplicated indices (a single table can have many reports on that)

An example: https://wikia-inc.atlassian.net/browse/SER-1773?focusedCommentId=422843&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-422843