### PR TITLE
SUS-5884 | report celery-worker errors

### DIFF
--- a/reporter/bin/check.py
+++ b/reporter/bin/check.py
@@ -13,7 +13,8 @@ from reporter.sources import PHPErrorsSource, PHPExceptionsSource, DBQueryErrors
     PHPAssertionsSource, PandoraErrorsSource, PHPSecuritySource, \
     MercurySource, HeliosSource, VignetteThumbVerificationSource, AnemometerSource, \
     ChatLogsSource, PHPExecutionTimeoutSource, BackendSource, PHPTriggeredSource, \
-    IndexDigestSource, ReportsPipeSource, DBReadQueryOnMaster, PHPTypeErrorsSource
+    IndexDigestSource, ReportsPipeSource, DBReadQueryOnMaster, PHPTypeErrorsSource, \
+    CeleryLogsSource
 
 logging.basicConfig(
     level=logging.INFO,
@@ -75,7 +76,6 @@ reports += AnemometerSource().query(threshold=0)
 reports += ChatLogsSource().query('uncaughtException', threshold=1)
 reports += ChatLogsSource().query('SyntaxError', threshold=1)
 
-# @see https://kibana5.wikia-inc.com/app/kibana#/discover/b4a08460-3633-11e7-8beb-4b869586dfbf?_g=(time%3A(from%3Anow-6h%2Cmode%3Aquick%2Cto%3Anow))
 reports += PHPExecutionTimeoutSource(period=21600).query(threshold=5)
 
 reports += BackendSource().query(threshold=2)
@@ -89,6 +89,8 @@ reports += ReportsPipeSource().query(threshold=1)
 reports += DBReadQueryOnMaster().query(threshold=1)
 
 reports += PHPTypeErrorsSource().query(threshold=5)
+
+reports += CeleryLogsSource().query(threshold=5)
 
 logging.info('Reporting {} issues...'.format(len(reports)))
 reporter = Jira()

--- a/reporter/bin/sandbox.py
+++ b/reporter/bin/sandbox.py
@@ -9,7 +9,7 @@ from reporter.sources import KilledDatabaseQueriesSource, PHPErrorsSource, \
     DBQueryNoLimitSource, DBQueryErrorsSource, PHPAssertionsSource, PHPExceptionsSource, \
     PandoraErrorsSource, PHPSecuritySource, MercurySource, HeliosSource, AnemometerSource, \
     ChatLogsSource, BackendSource, PHPTriggeredSource, IndexDigestSource, ReportsPipeSource, \
-    DBReadQueryOnMaster, PHPTypeErrorsSource
+    DBReadQueryOnMaster, PHPTypeErrorsSource, CeleryLogsSource
 
 from reporter.classifier import Classifier
 
@@ -26,7 +26,7 @@ classifier = Classifier()
 #reports += source.query("PHP Fatal Error", threshold=5)
 #reports += source.query("PHP Notice", threshold=2000)
 
-reports += KilledDatabaseQueriesSource().query(threshold=0)
+# reports += KilledDatabaseQueriesSource().query(threshold=0)
 
 #source = DBQueryNoLimitSource()
 #reports += source.query(threshold=50)
@@ -68,6 +68,8 @@ reports += KilledDatabaseQueriesSource().query(threshold=0)
 #reports += DBReadQueryOnMaster().query(threshold=1)
 
 #reports += PHPTypeErrorsSource().query(threshold=5)
+
+reports += CeleryLogsSource().query(threshold=2)
 
 for report in reports:
     print(report)

--- a/reporter/classifier/classifier.py
+++ b/reporter/classifier/classifier.py
@@ -3,7 +3,7 @@ import re
 import yaml
 
 from reporter.sources import PandoraErrorsSource, MercurySource, HeliosSource, ChatLogsSource, \
-    PHPExecutionTimeoutSource, BackendSource
+    PHPExecutionTimeoutSource, BackendSource, CeleryLogsSource
 
 
 class ClassifierConfig(object):
@@ -77,6 +77,9 @@ class Classifier(object):
         if PHPExecutionTimeoutSource.REPORT_LABEL in labels:
             # no component specified for this project
             return self.PROJECT_COMMUNITY_TECHNICAL, None
+
+        if CeleryLogsSource.REPORT_LABEL in labels:
+            return self.PROJECT_MAIN, self.get_component_id('celery workers')
 
         # classify using the report content and the paths inside it (always report to MAIN)
         description = report.get_description()

--- a/reporter/classifier/config/components.yaml
+++ b/reporter/classifier/config/components.yaml
@@ -11,6 +11,7 @@ components:
   Apester: 38421
   Article Video service: 38479
   AssetsManager: 26000
+  Athena: 38648
   Automatic Template Classification: 27602
   Backend Scripts: 26831
   Blogs: 11005
@@ -76,6 +77,7 @@ components:
   JS Review Tool: 31300
   JW Player: 38422
   Jenkins: 38200
+  LFS: 38638
   Lift Igniter Metadata service: 38300
   Lightbox: 28905
   Login & Signup: 11014
@@ -146,11 +148,13 @@ components:
   WikiFactory: 11028
   Wordpress: 33804
   aws: 35900
+  celery workers: 38676
   central-swagger-ui: 31400
   clickstream: 31401
   content-changed-ex.following: 31414
   dc-file-sync: 31402
   device-messaging: 31423
+  email: 38643
   external-auth: 31403
   following: 31418
   i18n: 11011

--- a/reporter/sources/__init__.py
+++ b/reporter/sources/__init__.py
@@ -2,18 +2,18 @@
 Export classes than will be used by "bin" scripts and tests
 """
 
-from common import Source
+from .common import Source
 
-from anemometer import AnemometerSource
-from backend import BackendSource
-from caching import NotCachedWikiaApiResponsesSource
+from .anemometer import AnemometerSource
+from .backend import BackendSource
+from .caching import NotCachedWikiaApiResponsesSource
 from .celery import CeleryLogsSource
-from helios import HeliosSource
-from mercury import MercurySource
-from mysql_kill import KilledDatabaseQueriesSource
-from pipe import ReportsPipeSource
-from php import *
-from pandora import PandoraErrorsSource
-from vignette import VignetteThumbVerificationSource
-from chat import ChatLogsSource
-from indexdigest import IndexDigestSource
+from .helios import HeliosSource
+from .mercury import MercurySource
+from .mysql_kill import KilledDatabaseQueriesSource
+from .pipe import ReportsPipeSource
+from .php import *
+from .pandora import PandoraErrorsSource
+from .vignette import VignetteThumbVerificationSource
+from .chat import ChatLogsSource
+from .indexdigest import IndexDigestSource

--- a/reporter/sources/__init__.py
+++ b/reporter/sources/__init__.py
@@ -7,6 +7,7 @@ from common import Source
 from anemometer import AnemometerSource
 from backend import BackendSource
 from caching import NotCachedWikiaApiResponsesSource
+from .celery import CeleryLogsSource
 from helios import HeliosSource
 from mercury import MercurySource
 from mysql_kill import KilledDatabaseQueriesSource

--- a/reporter/sources/celery/__init__.py
+++ b/reporter/sources/celery/__init__.py
@@ -1,0 +1,2 @@
+# expose all Celery-related sources
+from .celery import CeleryLogsSource

--- a/reporter/sources/celery/celery.py
+++ b/reporter/sources/celery/celery.py
@@ -1,0 +1,85 @@
+from reporter.sources.common import KibanaSource
+from reporter.reports import Report
+import json
+
+
+class CeleryLogsSource(KibanaSource):
+    """
+    Get Celery worker logs from elasticsearch
+
+    @see https://github.com/Wikia/celery-workers
+    @see https://kibana.wikia-inc.com/goto/913d8072c075be08be388b3a7d9fe167
+    """
+    REPORT_TEMPLATE = """
+Celery worker has reported the following error when processing *{queue}* queue:
+
+{{code}}
+{error}
+{{code}}
+
+h3. Details
+
+{{code}}
+{details}
+{{code}}
+
+*Flower link*: {flower_link}
+    """
+
+    LIMIT = 1500
+
+    REPORT_LABEL = 'CeleryWorkersError'
+
+    ELASTICSEARCH_INDEX_PREFIX = 'logstash-celery'
+
+    def _get_entries(self, query):
+        """ Return entries matching given query """
+        return self._kibana.query_by_string(
+            query='event: "Task failed" AND  kubernetes.namespace_name: "prod"',
+            limit=self.LIMIT
+        )
+
+    def _filter(self, entry):
+        return True
+
+    def _get_kibana_url(self, entry):
+        return self.format_kibana_url(
+            query='@context.task_id: "{taskid}"'.format(
+                taskid=entry.get('task_id')
+            ),
+            columns=['@timestamp', '@message'],
+            index='logstash-mediawiki'
+        )
+
+    def _normalize(self, entry):
+        """
+        Normalize given entry
+        """
+        return 'Celery-{}-{}'.format(
+            entry.get('kubernetes').get('container_name'),
+            entry.get('exception'),
+        )
+
+    def _get_report(self, entry):
+        """ Format the report to be sent to JIRA """
+        exception = entry.get('exception')
+        queue = entry.get('kubernetes').get('container_name')
+        task_id = entry.get('task_id')
+
+        description = self.REPORT_TEMPLATE.format(
+            queue=queue,
+            error=entry.get('exception'),
+            details=json.dumps(entry, indent=True),
+            flower_link='http://celery-flower.{dc}.k8s.wikia.net/task/{task_id}'.format(
+                dc=entry.get('datacenter').lower(), task_id=task_id)
+        ).strip()
+
+        report = Report(
+            summary='Celery worker {} reported: {}'.format(queue, exception),
+            description=description,
+            label=self.REPORT_LABEL
+        )
+
+        report.add_label(queue)
+
+        return report

--- a/reporter/test/test_celery_source.py
+++ b/reporter/test/test_celery_source.py
@@ -1,0 +1,63 @@
+"""
+Set of unit tests for CeleryLogsSource
+"""
+import unittest
+
+from ..sources import CeleryLogsSource
+
+
+class CeleryLogsSourceTestClass(unittest.TestCase):
+    """
+    Unit tests for CeleryLogsSource class
+    """
+    def setUp(self):
+        self._source = CeleryLogsSource()
+
+    def test_report(self):
+        report = self._source._get_report(
+            {
+                "syslog_timestamp": "2018-10-04 13:17:56,211",
+                "event": "Task failed",
+                "datacenter": "SJC",
+                "exception_type": "RemoteExecuteError",
+                "es_index": "celery",
+                "@timestamp": "2018-10-04T13:17:56.211Z",
+                "tags": [
+                    "json"
+                ],
+                "kubernetes": {
+                    "pod_name": "celery-mediawiki-main-58754999c5-rcp5g",
+                    "master_url": "https://10.220.0.1:443/api",
+                    "namespace_id": "29f07d84-1eb7-11e7-95d6-525400146bee",
+                    "labels": {
+                        "app": "celery-mediawiki-main",
+                        "pod-template-hash": "1431055571"
+                    },
+                    "namespace_name": "prod",
+                    "container_name": "mediawiki-main",
+                    "cluster_name": "kube-sjc-prod",
+                    "pod_id": "156b5bd8-c7a5-11e8-8105-525400702077",
+                    "namespace_annotations": {
+                        "kubectl_kubernetes_io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"prod\",\"namespace\":\"\"},\"spec\":{\"finalizers\":[\"kubernetes\"]}}\n"
+                    },
+                    "host": "k8s-worker-s21"
+                },
+                "exception": "RemoteExecuteError(u'Wikia\\\\SwiftSync\\\\ImageSyncTask::synchronize',)",
+                "stream": "stderr",
+                "docker": {
+                    "container_id": "c9334973842ce82ce13bd2604a33e61c788e4e3ea35f3b3f24a590cfe043f452"
+                },
+                "@version": "1",
+                "task_id": "mw-F9D9236F-73CA-4608-9E98-BAFE2A7A9359"
+            }
+        )
+
+        desc = report.get_description()
+
+        print(desc)
+
+        assert 'Celery worker has reported the following error when processing *mediawiki-main* queue:' in desc
+        assert '*Flower link*: http://celery-flower.sjc.k8s.wikia.net/task/mw-F9D9236F-73CA-4608-9E98-BAFE2A7A935' in desc
+
+        assert "Celery worker mediawiki-main reported: RemoteExecuteError(u'Wikia\\\\SwiftSync\\\\ImageSyncTask::synchronize',)" == report.get_summary()
+        assert ['CeleryWorkersError', 'mediawiki-main'] == report.get_labels()


### PR DESCRIPTION
```
2018-10-05 09:19:25 CeleryLogsSource                    INFO     Got 1500 entries after filtering
2018-10-05 09:19:25 CeleryLogsSource                    INFO     Returning 3 reports (with threshold set to 2 applied)
2018-10-05 09:19:25 CeleryLogsSource                    INFO     > Celery worker mediawiki-main reported: Timeout(ReadTimeoutError("HTTPConnectionPool(host='prod.task.service.consul', port=80): Read timed out. (read timeout=180)",),) (36 instances)
2018-10-05 09:19:25 CeleryLogsSource                    INFO     > Celery worker mediawiki-priority reported: InvalidResponseError('No JSON object could be decoded',) (2 instances)
2018-10-05 09:19:25 CeleryLogsSource                    INFO     > Celery worker parsoid-purger-priority reported: RemoteExecuteError(u'Could not resolve host: prod.parsoid-cache',) (1462 instances)
```