### PR TITLE
PLATFORM-5310 | Set correct unique_id hash for UCP issues

### DIFF
--- a/reporter/sources/common.py
+++ b/reporter/sources/common.py
@@ -118,9 +118,11 @@ class Source(object):
                 continue
 
             # update the report with the "hash" generated previously via _normalize
-            m = hashlib.md5()
-            m.update(key.encode('utf-8'))
-            report.set_unique_id(m.hexdigest())
+            # also allow to override unique_id implementation by eg. Source classes
+            if not report.get_unique_id():
+                m = hashlib.md5()
+                m.update(key.encode('utf-8'))
+                report.set_unique_id(m.hexdigest())
 
             report.set_counter(item['cnt'])
             reports.append(report)

--- a/reporter/sources/ucp/errors.py
+++ b/reporter/sources/ucp/errors.py
@@ -1,4 +1,5 @@
 import re
+import hashlib
 import urllib.parse
 
 from reporter.reports import Report
@@ -127,6 +128,15 @@ class UCPErrorsSource(KibanaSource):
             description=description,
             priority=priority
         )
+
+        # Most of the not detected duplicates are caused by wikiId or ArticleID
+        # we should remove them from hash, as message summary should be sufficient
+        # enough the deliver "unique" key for the issue because of the error message or
+        # path to the file were it was thrown.
+        m = hashlib.md5()
+        hash_text = re.sub(r'\d', '', report.get_summary())
+        m.update(hash_text.encode('utf-8'))
+        report.set_unique_id(m.hexdigest())
 
         report.add_label('unified-platform')
 

--- a/reporter/test/resources/ucp_error_titles.json
+++ b/reporter/test/resources/ucp_error_titles.json
@@ -1,0 +1,21 @@
+{
+	"unique_titles": [
+		"PHP Notice: Undefined property: StubObject::$mOutput in /extensions/fandom/Blogs/src/BlogTemplate.php on line 961",
+		"PHP Fatal Error: OOUI\\Exception: OOUI\\Theme::singleton was called with no singleton theme set. in /usr/wikia/slot1/current/src/vendor/oojs/oojs-ui/php/Theme.php:31",
+		"PHP Notice: Undefined index: X in /extensions/TippingOver/includes/WikiTooltips.php on line 538",
+		"PHP Notice: Undefined offset: N in /extensions/fandom/WikiaInYourLang/src/WikiaInYourLangService.php on line 83",
+		"PHP Notice: Trying to get property 'name' of non-object in /extensions/RSSPie/RSSPieHooks.php on line 221",
+		"PHP Warning: Illegal string offset 'title' in /extensions/fandom/Blogs/src/BlogTemplate.php on line 424",
+		"TypeError from line 20 of /extensions/fandom/FandomIncludes/src/Image/Image.php: Argument 4 passed to Fandom\\Includes\\Image\\Image::__construct() must be an instance of Fandom\\Includes\\Image\\ImageMetadata, null given, called in /usr/wikia/slot1/current/src/extensions/fandom/FandomIncludes/src/Image/Internal/DBImageRepository.php on line 221",
+		"PHP Notice: Undefined offset: N in /extensions/Cargo/includes/CargoSQLQuery.php on line 601",
+		"PHP Notice: Undefined index: X in /includes/libs/filebackend/FileBackend.php on line 1086",
+		"PHP Warning: Invalid argument supplied for foreach() in /includes/libs/filebackend/FileBackendStore.php on line 822",
+		"PHP Notice: Undefined index: X in /extensions/fandom/FandomIncludes/src/Image/Internal/DBImageRepository.php on line 221",
+		"PHP Warning: Mixed numeric and associative arrays are not supported in /extensions/fandom/FandomIncludes/src/Util/MustacheService.php on line 162",
+		"PHP Warning: Declaration of SpecialCategorySkins::execute(?string $path = NULL) should be compatible with SpecialPage::execute($subPage) in /extensions/CategorySkins/specials/SpecialCategorySkins.php on line 0",
+		"PHP Notice: Undefined variable: title in /extensions/fandom/MercuryApi/src/MercuryApiController.php on line 390",
+		"Error from line 390 of /extensions/fandom/MercuryApi/src/MercuryApiController.php: Call to a member function isExternal() on null",
+		"PHP Notice: Undefined index: X in /extensions/fandom/Lightbox/LightboxController.php on line 208",
+		"PHP Warning: Illegal string offset 'ns' in /extensions/fandom/Blogs/src/BlogTemplate.php on line 424"
+	]
+}


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/PLATFORM-5310

## Description
Currently we generate unique hash based on whole description which have urls, wiki ID etc. This causes many duplicates reported as issues. We should remove those variables before generating hashes, and this should allow to detect more duplicates.

## Who might be interested?
@Wikia/core-platform-team 