### PR TITLE
Set explicitly security context to be compliant with Pod Security Standards

### DIFF
--- a/docker/cronjob.yaml
+++ b/docker/cronjob.yaml
@@ -34,6 +34,14 @@ spec:
             volumeMounts:
             - name: secrets-dir
               mountPath: /var/lib/secrets
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
           containers:
           - name: jira-reporter
             image: artifactory.wikia-inc.com/sus/jira-reporter:latest
@@ -46,6 +54,14 @@ spec:
                 memory: 3000Mi
               requests:
                 memory: 2000Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
           volumes:
           - name: secrets-dir
             emptyDir:


### PR DESCRIPTION
This is part of migration from PodSecurityPolicy to the PodSecurity Admission Controller [1]. Some security parameters which are implicitly injected by PodSecurityPolicy mutating admission webhooks, need to be explicitly set to be compliant with Pod Security Standards [2].
Adding those security parameters don't change how workload is functioning because currently they are injected into manifest spec during Pod creation.

[1] https://fandom.atlassian.net/browse/OPS-13747
[2] https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted