### PR TITLE
Update k8s API version for CronJob deploy error

### DIFF
--- a/docker/cronjob.yaml
+++ b/docker/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jira-reporter


### PR DESCRIPTION
Old version throws:
```
❯ kubectl --context=kube-sjc-prod --namespace=prod apply --filename=docker/cronjob.yaml

error: resource mapping not found for name: "jira-reporter" namespace: "" from "docker/cronjob.yaml": no matches for kind "CronJob" in version "batch/v1beta1"
ensure CRDs are installed first
```

New API version:
```
❯ kubectl --context=kube-sjc-prod --namespace=prod apply --filename=docker/cronjob.yaml

cronjob.batch/jira-reporter created
```



